### PR TITLE
TRT - remove unintended text from header

### DIFF
--- a/CIRG-PainTracker-TRT.json
+++ b/CIRG-PainTracker-TRT.json
@@ -570,7 +570,7 @@
     },
     {
       "linkId": "TRT-3-header",
-      "text": "To the best of your recollection, which were the following treatments that you tried for your pain in the LAST 6 MONTHS? (TRT-3*1)",
+      "text": "To the best of your recollection, which were the following treatments that you tried for your pain in the LAST 6 MONTHS?",
       "type": "string"
     },
     {


### PR DESCRIPTION
remove `(TRT-3*1)` from one of the question header texts (I think that wasn't intended)

(see screenshot with errant text)

![Screenshot 2024-09-19 at 11 25 01 AM](https://github.com/user-attachments/assets/60683cd3-6aa1-4587-882c-f83e57855211)
