### PR TITLE
Adds three more CNICS questionnaires: financial, food & housing.

### DIFF
--- a/CIRG-CNICS-FINANCIAL.json
+++ b/CIRG-CNICS-FINANCIAL.json
@@ -1,0 +1,40 @@
+{
+  "resourceType": "Questionnaire",
+  "id": "CIRG-CNICS-FINANCIAL",
+  "title": "CNICS Financial Situation Questionnaire",
+  "status": "active",
+  "description": "CNICS Financial situation questionnaire. Based on: Rice E, Green S, Santos K, Lester P, Rotheram-Borus MJ. A lifetime of low-risk behaviors among HIV-positive Latinas in Los Angeles. J Immigr Minor Health. 2010;12(6):875-881.",
+  "item": [
+    {
+      "linkId": "FINANCIAL-0",
+      "text": "Which of the following best describes your financial situation?",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "FINANCIAL-0-0",
+            "display": "Struggling to survive, not enough money to pay bills and buy food"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "FINANCIAL-0-1",
+            "display": "Barely paying the bills"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "FINANCIAL-0-2",
+            "display": "Have the necessities, have money to cover needs"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "FINANCIAL-0-2",
+            "display": "Comfortable, have money to purchase extras"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/CIRG-CNICS-FINANCIAL.json
+++ b/CIRG-CNICS-FINANCIAL.json
@@ -30,8 +30,38 @@
         },
         {
           "valueCoding": {
-            "code": "FINANCIAL-0-2",
+            "code": "FINANCIAL-0-3",
             "display": "Comfortable, have money to purchase extras"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "FINANCIAL-score-label",
+      "text": "Financial Situation Questionnaire score: label",
+      "type": "string",
+      "readOnly": true,
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "iif(%resource.item.where(linkId='FINANCIAL-0').answer.valueCoding.code = 'FINANCIAL-0-0', 'Struggling to survive', iif(%resource.item.where(linkId='FINANCIAL-0').answer.valueCoding.code = 'FINANCIAL-0-1', 'Barely paying the bills', iif(%resource.item.where(linkId='FINANCIAL-0').answer.valueCoding.code = 'FINANCIAL-0-2', 'Has necessities', iif(%resource.item.where(linkId='FINANCIAL-0').answer.valueCoding.code = 'FINANCIAL-0-3', 'Comfortable', null))))"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "FINANCIAL-critical-flag",
+      "text": "Financial Situation Questionnaire score: critical flag",
+      "type": "boolean",
+      "readOnly": true,
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "%resource.item.where(linkId='FINANCIAL-0').answer.valueCoding.code = 'FINANCIAL-0-0'"
           }
         }
       ]

--- a/CIRG-CNICS-FOOD.json
+++ b/CIRG-CNICS-FOOD.json
@@ -1,0 +1,64 @@
+{
+  "resourceType": "Questionnaire",
+  "id": "CIRG-CNICS-FOOD",
+  "title": "CNICS Food Security Questionnaire (FSQ)",
+  "status": "active",
+  "description": "CNICS Food Security Questionnaire (FSQ). Based on: Young J, Jeganathan S, Houtzager L, Di Guilmi A, Purnomo J. A valid two-item food security questionnaire for screening HIV-1 infected patients in a clinical setting. Public Health Nutr. 2009;12(11):2129-2132.",
+  "item": [
+    {
+      "linkId": "FOOD-header",
+      "text": "Please read the following two statements and indicate whether the statement was OFTEN, SOMETIMES, or NEVER true for you or other members of your household in the last 12 months.",
+      "type": "display"
+    },
+    {
+      "linkId": "FOOD-0",
+      "text": "The food I/we bought just didn't last, and I/we didn't have money to get more.",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "FOOD-0-0",
+            "display": "Never true"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "FOOD-0-1",
+            "display": "Sometimes true"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "FOOD-0-2",
+            "display": "Often true"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "FOOD-1",
+      "text": "I/we couldn't afford to eat balanced meals.",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "FOOD-1-0",
+            "display": "Never true"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "FOOD-1-1",
+            "display": "Sometimes true"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "FOOD-1-2",
+            "display": "Often true"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/CIRG-CNICS-FOOD.json
+++ b/CIRG-CNICS-FOOD.json
@@ -59,6 +59,36 @@
           }
         }
       ]
+    },
+    {
+      "linkId": "FOOD-score",
+      "text": "Food Security Questionnaire score",
+      "type": "decimal",
+      "readOnly": true,
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "iif(%resource.item.where(linkId='FOOD-0').answer.empty() and %resource.item.where(linkId='FOOD-1').answer.empty(), null, iif(%resource.item.where(linkId='FOOD-0').answer.valueCoding.empty() xor %resource.item.where(linkId='FOOD-1').answer.valueCoding.empty(), iif(%resource.item.where(linkId='FOOD-0').answer.valueCoding.code = 'FOOD-0-0' or %resource.item.where(linkId='FOOD-1').answer.valueCoding.code = 'FOOD-1-0', null, 1), iif(%resource.item.where(linkId='FOOD-0').answer.valueCoding.code.replace('FOOD-0-','').toInteger() = 0, iif(%resource.item.where(linkId='FOOD-1').answer.valueCoding.code.replace('FOOD-1-','').toInteger() = 0, 0, 1), iif(%resource.item.where(linkId='FOOD-1').answer.valueCoding.code.replace('FOOD-1-','').toInteger() = 0, 1, 2))))"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "FOOD-critical-flag",
+      "text": "Food Security Questionnaire score: critical flag",
+      "type": "boolean",
+      "readOnly": true,
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "%resource.item.where(linkId='FOOD-score').answer.valueDecimal > 0"
+          }
+        }
+      ]
     }
   ]
 }

--- a/CIRG-CNICS-FOOD.json
+++ b/CIRG-CNICS-FOOD.json
@@ -85,7 +85,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
           "valueExpression": {
             "language": "text/fhirpath",
-            "expression": "%resource.item.where(linkId='FOOD-score').answer.valueDecimal > 0"
+            "expression": "%resource.item.where(linkId='FOOD-score').answer.valueDecimal.toInteger() > 0"
           }
         }
       ]

--- a/CIRG-CNICS-FOOD.json
+++ b/CIRG-CNICS-FOOD.json
@@ -76,6 +76,21 @@
       ]
     },
     {
+      "linkId": "FOOD-score-label",
+      "text": "Food Security Questionnaire score: label",
+      "type": "string",
+      "readOnly": true,
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "iif(%resource.item.where(linkId='FOOD-score').answer.valueDecimal.toInteger() = 0, 'Food Secure', iif(%resource.item.where(linkId='FOOD-score').answer.valueDecimal.toInteger() = 1, 'Low Food Security', iif(%resource.item.where(linkId='FOOD-score').answer.valueDecimal.toInteger() = 2, 'Very Low Food Security', null)))"
+          }
+        }
+      ]
+    },
+    {
       "linkId": "FOOD-critical-flag",
       "text": "Food Security Questionnaire score: critical flag",
       "type": "boolean",

--- a/CIRG-CNICS-HOUSING.json
+++ b/CIRG-CNICS-HOUSING.json
@@ -1,0 +1,102 @@
+{
+  "resourceType": "Questionnaire",
+  "id": "CIRG-CNICS-HOUSING",
+  "title": "CNICS Housing Measure",
+  "status": "active",
+  "description": "CNICS Housing Measure. Reference: Whitney BM FE, Jackson MK, Brown SM, Nguyen J, Nance RN, Ruderman S, Delaney JAC, Crane HM, Fredericksen RJ. Patient perceptions and understanding of a housing status measure for use in HIV care. 27th Annual Conference of International Society of Quality of Life; October 19-23, 2020, 2020; online.",
+  "item": [
+    {
+      "linkId": "HOUSING-0",
+      "text": " In the past month, please check any of the following places in which you stayed at least one night (excluding vacation)?",
+      "type": "choice",
+      "repeats": "true",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "HOUSING-0-0",
+            "display": "A home or apartment that you own or rent (by yourself or with others)"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "HOUSING-0-1",
+            "display": "Someone else's home or apartment"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "HOUSING-0-2",
+            "display": "Room in a motel or hotel"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "HOUSING-0-3",
+            "display": "Residential program (e.g. drug treatment facility, halfway house)"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "HOUSING-0-4",
+            "display": "Hospital/Long-term care facility"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "HOUSING-0-5",
+            "display": "Shelter for those without housing"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "HOUSING-0-6",
+            "display": "Jail/Prison"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "HOUSING-0-7",
+            "display": "Outdoors, tent, abandoned building, public space, or in a car"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "HOUSING-0-8",
+            "display": "Don't know/Other"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "HOUSING-1",
+      "text": "In the past month, how would you describe your living situation?",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "HOUSING-1-0",
+            "display": "Homeless"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "HOUSING-1-1",
+            "display": "Unstable"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "HOUSING-1-2",
+            "display": "Stable"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "HOUSING-1-3",
+            "display": "Don't know"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -77,8 +77,10 @@ A repository of FHIR Questionnaires in json format. This is intended to be a def
       - CIRG-PC-PTSD-5.json
       - CIRG-PHQ-4.json
       - 1_Questionnaire-USAUDIT.json (screener app)
-  - item[n]."extension"[]."url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression"
-    - This can be used to specify a fhirpath expression for computing a score for the item. For en example, see [CIRG-CNICS-FOOD](https://github.com/uwcirg/fhir-questionnaires/blob/main/CIRG-CNICS-FOOD.json). Use the fhirpath standard `%resource` to refer to the QuestionnaireResponse - that's compatible with most current interpreters (e.g. [fhirpath.js](https://github.com/HL7/fhirpath.js/pull/180/files)); see also https://gitlab.cirg.washington.edu/svn/dhair/-/issues/209.
+  - item[n].extension[] with url: "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression" and valueExpression.language = "text/fhirpath"
+    - This can be used to specify a fhirpath expression for computing the score for an item. For examples with string and boolean scores, see [CIRG-CNICS-FOOD](https://github.com/uwcirg/fhir-questionnaires/blob/main/CIRG-CNICS-FOOD.json).
+    - Use the fhirpath standard `%resource` to refer to the QuestionnaireResponse - that's compatible with most current interpreters (e.g. [fhirpath.js](https://github.com/HL7/fhirpath.js/pull/180/files)).
+    - See also https://gitlab.cirg.washington.edu/svn/dhair/-/issues/209.
   - item[n]."extension"."valueCoding"
     - We sometimes use this to indicate that an item is a score [here](https://github.com/uwcirg/fhir-questionnaires/pull/2/files#diff-66fd6a93556a044e8ffa3a290dac3e49b37b29b60c0cdddfb2645fe5cea49ae2R582)
     - As of 2023-10-12 we don't have code that reads this.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ A repository of FHIR Questionnaires in json format. This is intended to be a def
       - CIRG-PHQ-4.json
       - 1_Questionnaire-USAUDIT.json (screener app)
   - item[n]."extension"[]."url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression"
-    - This can be used to specify a fhirpath expression to compute a score. For en example, see [CIRG-CNICS-FOOD](https://github.com/uwcirg/fhir-questionnaires/blob/main/CIRG-CNICS-FOOD.json).
+    - This can be used to specify a fhirpath expression for computing a score for the item. For en example, see [CIRG-CNICS-FOOD](https://github.com/uwcirg/fhir-questionnaires/blob/main/CIRG-CNICS-FOOD.json). Use the fhirpath standard `%resource` to refer to the QuestionnaireResponse - that's compatible with most current interpreters (e.g. [fhirpath.js](https://github.com/HL7/fhirpath.js/pull/180/files)); see also https://gitlab.cirg.washington.edu/svn/dhair/-/issues/209.
   - item[n]."extension"."valueCoding"
     - We sometimes use this to indicate that an item is a score [here](https://github.com/uwcirg/fhir-questionnaires/pull/2/files#diff-66fd6a93556a044e8ffa3a290dac3e49b37b29b60c0cdddfb2645fe5cea49ae2R582)
     - As of 2023-10-12 we don't have code that reads this.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ A repository of FHIR Questionnaires in json format. This is intended to be a def
       - 1_Questionnaire-USAUDIT.json (screener app)
   - item[n].extension[] with url: "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression" and valueExpression.language = "text/fhirpath"
     - This can be used to specify a fhirpath expression for computing the score for an item. For examples with valueDecimal (for numerical score), valueString (score label), and valueBoolean (whether the critical threshold was met), see [CIRG-CNICS-FOOD](https://github.com/uwcirg/fhir-questionnaires/blob/main/CIRG-CNICS-FOOD.json).
+    - Note that if one item's fhirpath expression depends on another item's value, the [SDC Form Filler](https://hl7.org/fhir/uv/sdc/CapabilityStatement-sdc-form-filler.html) assembling the QuestionnaireResponse should calculate dependencies first. What I found in [dhair]([url](https://gitlab.cirg.washington.edu/svn/dhair/-/issues/209)) was that the FHIR server (Hapi) returns the array of Questionnaire.items in a consistent sequence (as it was written to it), facilitating this.
     - Use the fhirpath standard `%resource` to refer to the QuestionnaireResponse - that's compatible with most current interpreters (e.g. [fhirpath.js](https://github.com/HL7/fhirpath.js/pull/180/files)).
     - See also https://gitlab.cirg.washington.edu/svn/dhair/-/issues/209.
   - item[n]."extension"."valueCoding"

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ A repository of FHIR Questionnaires in json format. This is intended to be a def
       - CIRG-PHQ-4.json
       - 1_Questionnaire-USAUDIT.json (screener app)
   - item[n].extension[] with url: "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression" and valueExpression.language = "text/fhirpath"
-    - This can be used to specify a fhirpath expression for computing the score for an item. For examples with string and boolean scores, see [CIRG-CNICS-FOOD](https://github.com/uwcirg/fhir-questionnaires/blob/main/CIRG-CNICS-FOOD.json).
+    - This can be used to specify a fhirpath expression for computing the score for an item. For examples with valueDecimal (for numerical score), valueString (score label), and valueBoolean (whether the critical threshold was met), see [CIRG-CNICS-FOOD](https://github.com/uwcirg/fhir-questionnaires/blob/main/CIRG-CNICS-FOOD.json).
     - Use the fhirpath standard `%resource` to refer to the QuestionnaireResponse - that's compatible with most current interpreters (e.g. [fhirpath.js](https://github.com/HL7/fhirpath.js/pull/180/files)).
     - See also https://gitlab.cirg.washington.edu/svn/dhair/-/issues/209.
   - item[n]."extension"."valueCoding"

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ A repository of FHIR Questionnaires in json format. This is intended to be a def
       - CIRG-PC-PTSD-5.json
       - CIRG-PHQ-4.json
       - 1_Questionnaire-USAUDIT.json (screener app)
+  - item[n]."extension"[]."url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression"
+    - This can be used to specify a fhirpath expression to compute a score. For en example, see [CIRG-CNICS-FOOD](https://github.com/uwcirg/fhir-questionnaires/blob/main/CIRG-CNICS-FOOD.json).
   - item[n]."extension"."valueCoding"
     - We sometimes use this to indicate that an item is a score [here](https://github.com/uwcirg/fhir-questionnaires/pull/2/files#diff-66fd6a93556a044e8ffa3a290dac3e49b37b29b60c0cdddfb2645fe5cea49ae2R582)
     - As of 2023-10-12 we don't have code that reads this.


### PR DESCRIPTION
Starting with the CIRG-CNICS-FOOD Questionnaire here I'm adding Fhirpath expressions to Questionnaire resources that define how to calculate score items, including valueDecimal (the numerical score), valueString (score label), and valueBoolean (whether the critical threshold was met). These are compliant with [the Structured Data Capture IG](https://hl7.org/fhir/uv/sdc/).

There's more context in at https://github.com/uwcirg/patient-summary/pull/27#issuecomment-3578101531 .

SDC intends for [SDC Form Fillers](https://hl7.org/fhir/uv/sdc/CapabilityStatement-sdc-form-filler.html) to calculate and include score items during assembly of QuestionnaireResponses. dhair now has the capacity to interpret these fhirpath expressions in order to do this (see https://gitlab.cirg.washington.edu/svn/dhair/-/issues/209).

See the README.md edits in this PR for more info.