### PR TITLE
CNICS Sexual Risk Questionnaire

### DIFF
--- a/CIRG-CNICS-SEXUAL-RISK.json
+++ b/CIRG-CNICS-SEXUAL-RISK.json
@@ -1179,13 +1179,13 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
           "valueExpression": {
             "language": "text/fhirpath",
-            "expression": "'TBD'"
+            "expression": "iif((%resource.item.where(linkId='SEXUAL-RISK-SCORE-UNPROTECTED-ANAL').answer.valueString.toString = 'Yes' or %resource.item.where(linkId='SEXUAL-RISK-SCORE-UNPROTECTED-ORAL').answer.valueString.toString = 'Yes' or %resource.item.where(linkId='SEXUAL-RISK-SCORE-UNPROTECTED-VAGINAL').answer.valueString.toString = 'Yes'),'Yes',iif((%resource.item.where(linkId='SEXUAL-RISK-SCORE-UNPROTECTED-ANAL').answer.valueString.toString = 'I can\\'t remember' or %resource.item.where(linkId='SEXUAL-RISK-SCORE-UNPROTECTED-ORAL').answer.valueString.toString = 'I can\\'t remember' or %resource.item.where(linkId='SEXUAL-RISK-SCORE-UNPROTECTED-VAGINAL').answer.valueString.toString = 'I can\\'t remember'),'I can\\'t remember','No'))"
           }
         }
       ]
     },
     {
-      "linkId": "SEXUAL-RISK-SCORE-STI-EXPOSURE-FIXME-fhirpath",
+      "linkId": "SEXUAL-RISK-SCORE-STI-EXPOSURE-fhirpath",
       "text": "Whether the patient is concerned for STI exposure. If this is true, it should be flagged as critical.",
       "type": "boolean",
       "readOnly": true,
@@ -1194,7 +1194,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
           "valueExpression": {
             "language": "text/fhirpath",
-            "expression": "true"
+            "expression": "iif((%resource.item.where(linkId='SEXUAL-RISK-16').answer.valueCoding.code = 'SEXUAL-RISK-16-0') or (%resource.item.where(linkId='SEXUAL-RISK-17').answer.valueCoding.code = 'SEXUAL-RISK-17-0') or (%resource.item.where(linkId='SEXUAL-RISK-38').answer.valueCoding.code = 'SEXUAL-RISK-38-0') or (%resource.item.where(linkId='SEXUAL-RISK-39').answer.valueCoding.code = 'SEXUAL-RISK-39-0'), true, iif((%resource.item.where(linkId='SEXUAL-RISK-16').answer.valueCoding.code = 'SEXUAL-RISK-16-1') or (%resource.item.where(linkId='SEXUAL-RISK-17').answer.valueCoding.code = 'SEXUAL-RISK-17-1') or (%resource.item.where(linkId='SEXUAL-RISK-38').answer.valueCoding.code = 'SEXUAL-RISK-38-1') or (%resource.item.where(linkId='SEXUAL-RISK-39').answer.valueCoding.code = 'SEXUAL-RISK-39-1'), false,''))"
           }
         }
       ]

--- a/CIRG-CNICS-SEXUAL-RISK.json
+++ b/CIRG-CNICS-SEXUAL-RISK.json
@@ -1,0 +1,1030 @@
+{
+  "resourceType": "Questionnaire",
+  "id": "CIRG-CNICS-SEXUAL-RISK",
+  "title": "CNICS Sexual Risk Questionnaire - LOTS TODO HERE FIXME, SIMPLY COPIED FROM THE AUDIT",
+  "status": "active",
+  "description": "CNICS Sexual Risk Questionnaire. Based on: Fredericksen RJ, Mayer KH, Gibbons LE, et al. Development and Content Validation of a Patient-Reported Sexual Risk Measure for Use in Primary Care. J Gen Intern Med. 2018.",
+  "item": [
+    {
+      "linkId": "SEXUAL-RISK-header",
+      "text": "This portion of the questionnaire is about your use of alcoholic beverages during the PAST TWELVE MONTHS.",
+      "type": "display"
+    },
+    {
+      "linkId": "SEXUAL-RISK-0",
+      "text": "How often do you have a drink containing alcohol?",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-0-0",
+            "display": "Never",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 0
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-0-1",
+            "display": "Monthly or less",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 1 
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-0-2",
+            "display": "2 to 4 times a month",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 2
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-0-3",
+            "display": "2 to 3 times a week",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 3 
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-0-4",
+            "display": "4 to 5 times a week",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 4 
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-0-5",
+            "display": "6 or 7 times a week",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 4 
+                }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-Q0-score",
+      "text": "Score contribution from Q0. This is an internal item for other scores' calculations.",
+      "type": "decimal",
+      "readOnly": true,
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "iif(%resource.item.where(linkId='SEXUAL-RISK-0').answer.empty(), null, %resource.item.where(linkId='SEXUAL-RISK-0').answer.valueCoding.extension('http://hl7.org/fhir/StructureDefinition/ordinalValue').valueDecimal.toInteger())"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-1",
+      "text": "How many drinks containing alcohol do you have on a typical day when you are drinking?",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-1-0",
+            "display": "1",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 0
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-1-1",
+            "display": "2",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 0
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-1-2",
+            "display": "3",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 1
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-1-3",
+            "display": "4",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 1
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-1-4",
+            "display": "5",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 2
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-1-5",
+            "display": "6",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 2 
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-1-6",
+            "display": "7",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 3 
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-1-7",
+            "display": "8",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 3 
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-1-8",
+            "display": "9",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 3 
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-1-9",
+            "display": "10 or more",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 4 
+                }
+            ]
+          }
+        }
+      ],
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "%resource.item.where(linkId='SEXUAL-RISK-0').answer.valueCoding.code != 'SEXUAL-RISK-0-0'"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-2-not-male",
+      "text": "How often do you have four or more drinks on one occasion?",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-2-not-male-0",
+            "display": "Never",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 0 
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-2-not-male-1",
+            "display": "Less than monthly",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 1
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-2-not-male-2",
+            "display": "Monthly",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 2
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-2-not-male-3",
+            "display": "Weekly",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 3
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-2-not-male-4",
+            "display": "Daily or almost daily",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 4
+                }
+            ]
+          }
+        }
+      ],
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "((%patient.gender != 'male') or %patient.gender.exists() != true) and %resource.item.where(linkId='SEXUAL-RISK-0').answer.valueCoding.code != 'SEXUAL-RISK-0-0'"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-2-male",
+      "text": "How often do you have five or more drinks on one occasion?",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-2-male-0",
+            "display": "Never",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 0
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-2-male-1",
+            "display": "Less than monthly",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 1
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-2-male-2",
+            "display": "Monthly",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 2
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-2-male-3",
+            "display": "Weekly",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 3 
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-2-male-4",
+            "display": "Daily or almost daily",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 4 
+                }
+            ]
+          }
+        }
+      ],
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "%patient.gender.exists() and (%patient.gender = 'male') and (%resource.item.where(linkId='SEXUAL-RISK-0').answer.valueCoding.code != 'SEXUAL-RISK-0-0')"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-Q1-Q2-score",
+      "text": "Score contribution from Q1 & Q2. This is an internal item for other scores' calculations.",
+      "type": "decimal",
+      "readOnly": true,
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "(iif(%resource.item.where(linkId='SEXUAL-RISK-1').answer.empty(), 0, %resource.item.where(linkId='SEXUAL-RISK-1').answer.valueCoding.extension('http://hl7.org/fhir/StructureDefinition/ordinalValue').valueDecimal.toInteger()) + iif(%resource.item.where(linkId='SEXUAL-RISK-2-not-male').answer.empty(), 0, %resource.item.where(linkId='SEXUAL-RISK-2-not-male').answer.valueCoding.extension('http://hl7.org/fhir/StructureDefinition/ordinalValue').valueDecimal.toInteger()) + iif(%resource.item.where(linkId='SEXUAL-RISK-2-male').answer.empty(), 0, %resource.item.where(linkId='SEXUAL-RISK-2-male').answer.valueCoding.extension('http://hl7.org/fhir/StructureDefinition/ordinalValue').valueDecimal.toInteger()))"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-C-complete",
+      "text": "SEXUAL-RISK-C part of questionnaire (first three questions) complete. This is an internal item for other scores' calculations.",
+      "type": "boolean",
+      "readOnly": true,
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "%resource.item.where(linkId = 'SEXUAL-RISK-0').answer.valueCoding.code.exists() and (%resource.item.where(linkId = 'SEXUAL-RISK-0').answer.valueCoding.code = 'SEXUAL-RISK-0-0') or (%resource.item.where(linkId = 'SEXUAL-RISK-1').answer.valueCoding.code.exists() and (%resource.item.where(linkId = 'SEXUAL-RISK-2-not-male').answer.valueCoding.code.exists() or %resource.item.where(linkId = 'SEXUAL-RISK-2-male').answer.valueCoding.code.exists()))"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-C-score",
+      "text": "SEXUAL-RISK-C score (score for questions 0-2)",
+      "type": "decimal",
+      "readOnly": true,
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "%resource.item.where(linkId='SEXUAL-RISK-Q0-score').answer.valueDecimal.toInteger() + %resource.item.where(linkId='SEXUAL-RISK-Q1-Q2-score').answer.valueDecimal.toInteger()"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-C-score-interpretation",
+      "text": "CNICS SEXUAL-RISK-C score interpretation",
+      "type": "string",
+      "readOnly": true,
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "iif(%patient.gender = 'male' and %resource.item.where(linkId='SEXUAL-RISK-C-score').answer.valueDecimal.toInteger() >= 4, 'At-risk', iif(%patient.gender != 'male' and %resource.item.where(linkId='SEXUAL-RISK-C-score').answer.valueDecimal.toInteger() >= 3, 'At-risk', iif((%resource.item.where(linkId='SEXUAL-RISK-C-score').answer.empty() != true), 'Not at-risk', null)))"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-3",
+      "text": "How often during the past 12 months have you found that you were not able to stop drinking once you had started?",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-3-0",
+            "display": "Never",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 0
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-3-1",
+            "display": "Less than monthly",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 1
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-3-2",
+            "display": "Monthly",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 2
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-3-3",
+            "display": "Weekly",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 3 
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-3-4",
+            "display": "Daily or almost daily",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 4 
+                }
+            ]
+          }
+        }
+      ],
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "(%resource.item.where(linkId='SEXUAL-RISK-0').answer.valueCoding.code != 'SEXUAL-RISK-0-0' and (iif(%patient.gender = 'male' and %resource.item.where(linkId='SEXUAL-RISK-C-score').answer.valueDecimal.toInteger() >= 4, true, iif(%patient.gender != 'male' and %resource.item.where(linkId='SEXUAL-RISK-C-score').answer.valueDecimal.toInteger() >= 3), true, false)))"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-4",
+      "text": "How often during the past 12 months have you failed to do what was normally expected from you because of drinking?",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-4-0",
+            "display": "Never",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 0
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-4-1",
+            "display": "Less than monthly",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 1
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-4-2",
+            "display": "Monthly",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 2
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-4-3",
+            "display": "Weekly",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 3 
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-4-4",
+            "display": "Daily or almost daily",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 4 
+                }
+            ]
+          }
+        }
+      ],
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "(%resource.item.where(linkId='SEXUAL-RISK-0').answer.valueCoding.code != 'SEXUAL-RISK-0-0' and (iif(%patient.gender = 'male' and %resource.item.where(linkId='SEXUAL-RISK-C-score').answer.valueDecimal.toInteger() >= 4, true, iif(%patient.gender != 'male' and %resource.item.where(linkId='SEXUAL-RISK-C-score').answer.valueDecimal.toInteger() >= 3), true, false)))"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-5",
+      "text": "How often during the past 12 months have you needed a first drink in the morning to get yourself going after a heavy drinking session?",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-5-0",
+            "display": "Never",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 0
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-5-1",
+            "display": "Less than monthly",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 1
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-5-2",
+            "display": "Monthly",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 2
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-5-3",
+            "display": "Weekly",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 3 
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-5-4",
+            "display": "Daily or almost daily",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 4 
+                }
+            ]
+          }
+        }
+      ],
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "(%resource.item.where(linkId='SEXUAL-RISK-0').answer.valueCoding.code != 'SEXUAL-RISK-0-0' and (iif(%patient.gender = 'male' and %resource.item.where(linkId='SEXUAL-RISK-C-score').answer.valueDecimal.toInteger() >= 4, true, iif(%patient.gender != 'male' and %resource.item.where(linkId='SEXUAL-RISK-C-score').answer.valueDecimal.toInteger() >= 3), true, false)))"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-6",
+      "text": "How often during the past 12 months have you had a feeling of guilt or remorse after drinking?",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-6-0",
+            "display": "Never",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 0
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-6-1",
+            "display": "Less than monthly",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 1
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-6-2",
+            "display": "Monthly",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 2
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-6-3",
+            "display": "Weekly",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 3 
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-6-4",
+            "display": "Daily or almost daily",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 4 
+                }
+            ]
+          }
+        }
+      ],
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "(%resource.item.where(linkId='SEXUAL-RISK-0').answer.valueCoding.code != 'SEXUAL-RISK-0-0' and (iif(%patient.gender = 'male' and %resource.item.where(linkId='SEXUAL-RISK-C-score').answer.valueDecimal.toInteger() >= 4, true, iif(%patient.gender != 'male' and %resource.item.where(linkId='SEXUAL-RISK-C-score').answer.valueDecimal.toInteger() >= 3), true, false)))"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-7",
+      "text": "How often during the past 12 months have you been unable to remember what happened the night before because you had been drinking?",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-7-0",
+            "display": "Never",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 0
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-7-1",
+            "display": "Less than monthly",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 1
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-7-2",
+            "display": "Monthly",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 2
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-7-3",
+            "display": "Weekly",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 3 
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-7-4",
+            "display": "Daily or almost daily",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 4 
+                }
+            ]
+          }
+        }
+      ],
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "(%resource.item.where(linkId='SEXUAL-RISK-0').answer.valueCoding.code != 'SEXUAL-RISK-0-0' and (iif(%patient.gender = 'male' and %resource.item.where(linkId='SEXUAL-RISK-C-score').answer.valueDecimal.toInteger() >= 4, true, iif(%patient.gender != 'male' and %resource.item.where(linkId='SEXUAL-RISK-C-score').answer.valueDecimal.toInteger() >= 3), true, false)))"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-8",
+      "text": "Have you or someone else been injured as a result of your drinking?",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-8-0",
+            "display": "No",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 0 
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-8-1",
+            "display": "Yes, but not in the last 12 months",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 2
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-8-2",
+            "display": "Yes, during last 12 months",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 4
+                }
+            ]
+          }
+        }
+      ],
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "(%resource.item.where(linkId='SEXUAL-RISK-0').answer.valueCoding.code != 'SEXUAL-RISK-0-0' and (iif(%patient.gender = 'male' and %resource.item.where(linkId='SEXUAL-RISK-C-score').answer.valueDecimal.toInteger() >= 4, true, iif(%patient.gender != 'male' and %resource.item.where(linkId='SEXUAL-RISK-C-score').answer.valueDecimal.toInteger() >= 3), true, false)))"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-9",
+      "text": "Has a relative or friend or a doctor or another health worker been concerned about your drinking or suggested you cut down?",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-9-0",
+            "display": "No",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 0 
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-9-1",
+            "display": "Yes, but not in the last 12 months",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 2 
+                }
+            ]
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-9-2",
+            "display": "Yes, during last 12 months",
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 4
+                }
+            ]
+          }
+        }
+      ],
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "(%resource.item.where(linkId='SEXUAL-RISK-0').answer.valueCoding.code != 'SEXUAL-RISK-0-0' and (iif(%patient.gender = 'male' and %resource.item.where(linkId='SEXUAL-RISK-C-score').answer.valueDecimal.toInteger() >= 4, true, iif(%patient.gender != 'male' and %resource.item.where(linkId='SEXUAL-RISK-C-score').answer.valueDecimal.toInteger() >= 3), true, false)))"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-last-7-any-answers",
+      "text": "At least one of the last 7 questions has been answered. This is an internal item for other scores' calculations.",
+      "type": "boolean",
+      "readOnly": true,
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "%resource.item.where(linkId = 'SEXUAL-RISK-3').answer.valueCoding.code.exists() or %resource.item.where(linkId = 'SEXUAL-RISK-4').answer.valueCoding.code.exists() or %resource.item.where(linkId = 'SEXUAL-RISK-5').answer.valueCoding.code.exists() or %resource.item.where(linkId = 'SEXUAL-RISK-6').answer.valueCoding.code.exists() or %resource.item.where(linkId = 'SEXUAL-RISK-7').answer.valueCoding.code.exists() or %resource.item.where(linkId = 'SEXUAL-RISK-8').answer.valueCoding.code.exists() or %resource.item.where(linkId = 'SEXUAL-RISK-9').answer.valueCoding.code.exists()"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-last-7-complete",
+      "text": "Last 7 questions here have been answered. This is an internal item for other scores' calculations.",
+      "type": "boolean",
+      "readOnly": true,
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "%resource.item.where(linkId = 'SEXUAL-RISK-3').answer.valueCoding.code.exists() and %resource.item.where(linkId = 'SEXUAL-RISK-4').answer.valueCoding.code.exists() and %resource.item.where(linkId = 'SEXUAL-RISK-5').answer.valueCoding.code.exists() and %resource.item.where(linkId = 'SEXUAL-RISK-6').answer.valueCoding.code.exists() and %resource.item.where(linkId = 'SEXUAL-RISK-7').answer.valueCoding.code.exists() and %resource.item.where(linkId = 'SEXUAL-RISK-8').answer.valueCoding.code.exists() and %resource.item.where(linkId = 'SEXUAL-RISK-9').answer.valueCoding.code.exists()"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-complete",
+      "text": "SEXUAL-RISK questionnaire complete",
+      "type": "boolean",
+      "readOnly": true,
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "(%resource.item.where(linkId='SEXUAL-RISK-C-complete').answer.valueBoolean.toBoolean() = true and (iif((%resource.item.where(linkId='SEXUAL-RISK-C-score').answer.valueDecimal.toInteger() >= 4 and (%patient.gender = 'male')) and %resource.item.where(linkId='SEXUAL-RISK-last-7-complete').answer.valueBoolean.toBoolean() = true, true,   (iif((%resource.item.where(linkId='SEXUAL-RISK-C-score').answer.valueDecimal.toInteger() >= 3 and (%patient.gender != 'male')) and %resource.item.where(linkId='SEXUAL-RISK-last-7-complete').answer.valueBoolean.toBoolean() = true, true, false)))))"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-score",
+      "text": "CNICS SEXUAL-RISK score",
+      "type": "decimal",
+      "readOnly": true,
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "(%resource.item.where(linkId='SEXUAL-RISK-Q0-score').answer.valueDecimal.toInteger() + %resource.item.where(linkId='SEXUAL-RISK-Q1-Q2-score').answer.valueDecimal.toInteger() + iif(%resource.item.where(linkId='SEXUAL-RISK-3').answer.empty(), 0, %resource.item.where(linkId='SEXUAL-RISK-3').answer.valueCoding.extension('http://hl7.org/fhir/StructureDefinition/ordinalValue').valueDecimal.toInteger()) + iif(%resource.item.where(linkId='SEXUAL-RISK-4').answer.empty(), 0, %resource.item.where(linkId='SEXUAL-RISK-4').answer.valueCoding.extension('http://hl7.org/fhir/StructureDefinition/ordinalValue').valueDecimal.toInteger()) + iif(%resource.item.where(linkId='SEXUAL-RISK-5').answer.empty(), 0, %resource.item.where(linkId='SEXUAL-RISK-5').answer.valueCoding.extension('http://hl7.org/fhir/StructureDefinition/ordinalValue').valueDecimal.toInteger()) + iif(%resource.item.where(linkId='SEXUAL-RISK-6').answer.empty(), 0, %resource.item.where(linkId='SEXUAL-RISK-6').answer.valueCoding.extension('http://hl7.org/fhir/StructureDefinition/ordinalValue').valueDecimal.toInteger()) + iif(%resource.item.where(linkId='SEXUAL-RISK-7').answer.empty(), 0, %resource.item.where(linkId='SEXUAL-RISK-7').answer.valueCoding.extension('http://hl7.org/fhir/StructureDefinition/ordinalValue').valueDecimal.toInteger()) + iif(%resource.item.where(linkId='SEXUAL-RISK-8').answer.empty(), 0, %resource.item.where(linkId='SEXUAL-RISK-8').answer.valueCoding.extension('http://hl7.org/fhir/StructureDefinition/ordinalValue').valueDecimal.toInteger()) + iif(%resource.item.where(linkId='SEXUAL-RISK-9').answer.empty(), 0, %resource.item.where(linkId='SEXUAL-RISK-9').answer.valueCoding.extension('http://hl7.org/fhir/StructureDefinition/ordinalValue').valueDecimal.toInteger()))"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-score-interpretation",
+      "text": "CNICS SEXUAL-RISK score interpretation",
+      "type": "string",
+      "readOnly": true,
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "iif(%patient.gender = 'male' and %resource.item.where(linkId='SEXUAL-RISK-score').answer.valueDecimal.toInteger() >= 6, 'At-risk', iif(%patient.gender != 'male' and %resource.item.where(linkId='SEXUAL-RISK-score').answer.valueDecimal.toInteger() >= 5, 'At-risk', iif((%resource.item.where(linkId='SEXUAL-RISK-score').answer.empty() != true), 'Not at-risk', null)))"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-qnr-to-report",
+      "text": "Which CNICS SEXUAL-RISK score to display. Returns 'SEXUAL-RISK', 'SEXUAL-RISK-C', or null.",
+      "type": "string",
+      "readOnly": true,
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "iif(%resource.item.where(linkId='SEXUAL-RISK-last-7-any-answers').answer.valueBoolean.toBoolean() = true, 'SEXUAL-RISK', iif(%resource.item.where(linkId='SEXUAL-RISK-0').answer.empty() = false, 'SEXUAL-RISK-C', null))"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/CIRG-CNICS-SEXUAL-RISK.json
+++ b/CIRG-CNICS-SEXUAL-RISK.json
@@ -1,7 +1,7 @@
 {
   "resourceType": "Questionnaire",
   "id": "CIRG-CNICS-SEXUAL-RISK",
-  "title": "CNICS Sexual Risk Questionnaire - LOTS TODO HERE FIXME, SIMPLY COPIED FROM THE AUDIT",
+  "title": "CNICS Sexual Risk Questionnaire",
   "status": "active",
   "description": "CNICS Sexual Risk Questionnaire. Based on: Fredericksen RJ, Mayer KH, Gibbons LE, et al. Development and Content Validation of a Patient-Reported Sexual Risk Measure for Use in Primary Care. J Gen Intern Med. 2018.",
   "item": [
@@ -1065,16 +1065,136 @@
       ]
     },
     {
-      "linkId": "SEXUAL-RISK-Q0-score",
-      "text": "Score contribution from Q0. This is an internal item for other scores' calculations.",
-      "type": "decimal",
+      "linkId": "SEXUAL-RISK-SCORE-NUM-PARTNERS",
+      "text": "The answer to: Approximately how many sex partners have you had in the past 3 months?",
+      "type": "string",
       "readOnly": true,
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
           "valueExpression": {
             "language": "text/fhirpath",
-            "expression": "iif(%resource.item.where(linkId='SEXUAL-RISK-0').answer.empty(), null, %resource.item.where(linkId='SEXUAL-RISK-0').answer.valueCoding.extension('http://hl7.org/fhir/StructureDefinition/ordinalValue').valueDecimal.toInteger())"
+            "expression": "iif(%resource.item.where(linkId='SEXUAL-RISK-0').answer.empty(), 'Not answered', %resource.item.where(linkId='SEXUAL-RISK-0').answer.valueCoding.display)"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-SCORE-PARTNERS-GENDERS",
+      "text": "Genders of partner(s). THIS IS JUST A STUB, NOT YET USED.",
+      "type": "string",
+      "readOnly": true,
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "'TBD'"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-SCORE-PARTNERS-HIV-STATUS",
+      "text": "HIV status of partner(s), and whether they were prescribed PrEP. THIS IS JUST A STUB, NOT YET USED.",
+      "type": "string",
+      "readOnly": true,
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "'TBD'"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-SCORE-UNPROTECTED-ANAL",
+      "text": "Whether the patient had unprotected anal sex. This is for internal scoring purposes only.",
+      "type": "boolean",
+      "readOnly": true,
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "iif(%resource.item.where(linkId='SEXUAL-RISK-0').answer.empty(), 'Not answered', %resource.item.where(linkId='SEXUAL-RISK-0').answer.valueCoding.display)"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-SCORE-UNPROTECTED-ANAL-TYPE",
+      "text": "If the patient had unprotected anal sex, what type/proportion. THIS IS JUST A STUB, NOT YET USED.",
+      "type": "string",
+      "readOnly": true,
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "'TBD'"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-SCORE-UNPROTECTED-ORAL",
+      "text": "Whether the patient had unprotected oral sex. This is for internal scoring purposes only.",
+      "type": "boolean",
+      "readOnly": true,
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": ""
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-SCORE-UNPROTECTED-VAGINAL",
+      "text": "Whether the patient had unprotected vaginal sex. This is for internal scoring purposes only.",
+      "type": "boolean",
+      "readOnly": true,
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": ""
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-SCORE-UNPROTECTED",
+      "text": "Whether the patient had unprotected sex of any type.",
+      "type": "boolean",
+      "readOnly": true,
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": ""
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-SCORE-STI-EXPOSURE",
+      "text": "Whether the patient is concerned for STI exposure. If this is true, it should be flagged as critical.",
+      "type": "boolean",
+      "readOnly": true,
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": ""
           }
         }
       ]

--- a/CIRG-CNICS-SEXUAL-RISK.json
+++ b/CIRG-CNICS-SEXUAL-RISK.json
@@ -6,85 +6,1034 @@
   "description": "CNICS Sexual Risk Questionnaire. Based on: Fredericksen RJ, Mayer KH, Gibbons LE, et al. Development and Content Validation of a Patient-Reported Sexual Risk Measure for Use in Primary Care. J Gen Intern Med. 2018.",
   "item": [
     {
-      "linkId": "SEXUAL-RISK-header",
-      "text": "This portion of the questionnaire is about your use of alcoholic beverages during the PAST TWELVE MONTHS.",
-      "type": "display"
-    },
-    {
       "linkId": "SEXUAL-RISK-0",
-      "text": "How often do you have a drink containing alcohol?",
+      "text": "Approximately how many sex partners have you had in the past 3 months?",
       "type": "choice",
       "answerOption": [
         {
           "valueCoding": {
             "code": "SEXUAL-RISK-0-0",
-            "display": "Never",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 0
-                }
-            ]
+            "display": "None"
           }
         },
         {
           "valueCoding": {
             "code": "SEXUAL-RISK-0-1",
-            "display": "Monthly or less",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 1 
-                }
-            ]
+            "display": "1"
           }
         },
         {
           "valueCoding": {
             "code": "SEXUAL-RISK-0-2",
-            "display": "2 to 4 times a month",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 2
-                }
-            ]
+            "display": "2"
           }
         },
         {
           "valueCoding": {
             "code": "SEXUAL-RISK-0-3",
-            "display": "2 to 3 times a week",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 3 
-                }
-            ]
+            "display": "3"
           }
         },
         {
           "valueCoding": {
             "code": "SEXUAL-RISK-0-4",
-            "display": "4 to 5 times a week",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 4 
-                }
-            ]
+            "display": "4-5"
           }
         },
         {
           "valueCoding": {
             "code": "SEXUAL-RISK-0-5",
-            "display": "6 or 7 times a week",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 4 
-                }
-            ]
+            "display": "6-7"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-0-6",
+            "display": "8-10"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-0-7",
+            "display": "11-20"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-0-8",
+            "display": "more than 20"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-1",
+      "text": "What was the gender of your partner?",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-1-0",
+            "display": "Male"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-1-1",
+            "display": "Female"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-1-2",
+            "display": "Male-to-Female Transgender/Transgender Woman"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-1-3",
+            "display": "Female-to-Male Transgender/Transgender Man"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-1-4",
+            "display": "A gender not listed above"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-1-5",
+            "display": "I don't know"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-2",
+      "text": "To the best of your knowledge, what was the HIV status of your sex partner?",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-2-0",
+            "display": "HIV positive"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-2-1",
+            "display": "HIV negative"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-2-2",
+            "display": "HIV status unknown"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-3",
+      "text": "To the best of your knowledge, is this partner currently prescribed medications for HIV?",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-3-0",
+            "display": "Yes"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-3-1",
+            "display": "No"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-3-2",
+            "display": "I don't know"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-4",
+      "text": "\"PrEP\" is an %(srbiPrEPApprovalText), once-daily pill that can help protect HIV-negative partners from HIV. To the best of your knowledge, is your HIV-negative sex partner prescribed PrEP?",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-4-0",
+            "display": "Yes"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-4-1",
+            "display": "No"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-4-2",
+            "display": "I don't know"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-5",
+      "text": "Would you like more information about PrEP?",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-5-0",
+            "display": "Yes"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-5-1",
+            "display": "No"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-6",
+      "text": "In the past 3 months, with your HIV%(srbiSinglePartnerHIVStatusEN) partner, have you given oral sex without a condom or barrier protection? By oral sex, we mean when a mouth touches someone's genitals.",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-6-0",
+            "display": "Yes"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-6-1",
+            "display": "No"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-6-2",
+            "display": "Can't remember"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-7",
+      "text": "In the past 3 months, with your HIV%(srbiSinglePartnerHIVStatusEN) partner, have you received oral sex without a condom or barrier protection? By oral sex, we mean when a mouth touches someone's genitals.",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-7-0",
+            "display": "Yes"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-7-1",
+            "display": "No"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-7-2",
+            "display": "Can't remember"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-8",
+      "text": "In the past 3 months, with your HIV%(srbiSinglePartnerHIVStatusEN) partner, have you had anal sex without condoms%(srbiSexInsertiveText)? By this we mean %(srbiInsertPenisText) entering an anus (butt)%(srbiSinglePartnerAnalSexTopText).",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-8-0",
+            "display": "Yes"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-8-1",
+            "display": "No"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-8-2",
+            "display": "Can't remember"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-9",
+      "text": "In the past 3 months, with your HIV%(srbiSinglePartnerHIVStatusEN) partner, have you had anal sex without condoms%(srbiSexReceptiveText)? By this we mean %(srbiReceptivePenisText) entering your anus (butt)%(srbiSinglePartnerAnalSexBottomText).",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-9-0",
+            "display": "Yes"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-9-1",
+            "display": "No"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-9-2",
+            "display": "Can't remember"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-10",
+      "text": "In the past 3 months, with your HIV%(srbiSinglePartnerHIVStatusEN) partner, have you had vaginal sex without condoms%(srbiSexInsertiveText)? By this we mean %(srbiInsertPenisText) entering %(srbiPartnerVaginalText).",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-10-0",
+            "display": "Yes"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-10-1",
+            "display": "No"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-10-2",
+            "display": "Can't remember"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-11",
+      "text": "In the past 3 months, with your HIV%(srbiSinglePartnerHIVStatusEN) partner, have you had vaginal sex without condoms%(srbiSexReceptiveText)? By this we mean %(srbiReceptivePenisText) entering %(srbiVaginalText).",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-11-0",
+            "display": "Yes"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-11-1",
+            "display": "No"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-11-2",
+            "display": "Can't remember"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-12",
+      "text": "In the past 3 months, with your HIV%(srbiSinglePartnerHIVStatusEN) partner, have you had vaginal/frontal sex without %(srbiBarrierBirthControlEN)? By vaginal sex we mean a penis entering a vagina.",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-12-0",
+            "display": "Yes"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-12-1",
+            "display": "No"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-12-2",
+            "display": "Can't remember"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-13",
+      "text": "In the past 3 months, with your HIV%(srbiSinglePartnerHIVStatusEN) partner, have you had anal sex without a condom? By anal sex, we mean a penis entering an anus (butt).",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-13-0",
+            "display": "Yes"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-13-1",
+            "display": "No"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-13-2",
+            "display": "Can't remember"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-14",
+      "text": "In the past 3 months, with your HIV%(srbiSinglePartnerHIVStatusEN) partner, have you had oral sex without a condom or barrier protection? By oral sex, we mean when a mouth touches someone else's genitals.",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-14-0",
+            "display": "Yes"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-14-1",
+            "display": "No"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-14-2",
+            "display": "Can't remember"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-15",
+      "text": "In the past 3 months, thinking about the times you had anal sex without condoms, please mark on the line how often you were the \"bottom\" (receiving partner).",
+      "type": "integer"
+    },
+    {
+      "linkId": "SEXUAL-RISK-16",
+      "text": "In the past 3 months, have you been concerned that you may have been exposed to HIV or another kind of sexually transmitted infection (STI)?",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-16-0",
+            "display": "Yes"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-16-1",
+            "display": "No"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-17",
+      "text": "In the past 3 months, have you been concerned that you may have been exposed to a sexually transmitted infection (STI) or re-exposed to HIV?",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-17-0",
+            "display": "Yes"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-17-1",
+            "display": "No"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-18",
+      "text": "How many of your partners in the past 3 months were Male?",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-18-0",
+            "display": "All"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-18-1",
+            "display": "Most"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-18-2",
+            "display": "Some"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-18-3",
+            "display": "None"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-19",
+      "text": "How many of your partners in the past 3 months were Female?",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-19-0",
+            "display": "All"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-19-1",
+            "display": "Most"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-19-2",
+            "display": "Some"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-19-3",
+            "display": "None"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-20",
+      "text": "How many of your partners in the past 3 months were Male-to-Female Transgender/Transgender Women?",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-20-0",
+            "display": "All"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-20-1",
+            "display": "Most"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-20-2",
+            "display": "Some"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-20-3",
+            "display": "None"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-21",
+      "text": "How many of your partners in the past 3 months were Female-to-Male Transgender/Transgender Men?",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-21-0",
+            "display": "All"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-21-1",
+            "display": "Most"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-21-2",
+            "display": "Some"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-21-3",
+            "display": "None"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-22",
+      "text": "How many of your partners in the past 3 months were A gender not listed above?",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-22-0",
+            "display": "All"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-22-1",
+            "display": "Most"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-22-2",
+            "display": "Some"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-22-3",
+            "display": "None"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-23",
+      "text": "How many of your partners in the past 3 months were I don't know",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-23-0",
+            "display": "All"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-23-1",
+            "display": "Most"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-23-2",
+            "display": "Some"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-23-3",
+            "display": "None"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-24",
+      "text": "To the best of your knowledge, what were the HIV statuses of your sex partners? Please check all that apply.",
+      "type": "choice",
+      "repeats": true,
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-24-0",
+            "display": "HIV positive"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-24-1",
+            "display": "HIV negative"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-24-2",
+            "display": "HIV status unknown"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-24-3",
+            "display": "All of the above"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-25",
+      "text": "To the best of your knowledge, are any of your HIV-positive partner(s) currently prescribed medications for HIV?",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-25-0",
+            "display": "Yes, all are"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-25-1",
+            "display": "Some are"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-25-2",
+            "display": "No, none are"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-25-3",
+            "display": "I don't know"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-26",
+      "text": "\"PrEP\" is an %(srbiPrEPApprovalText), once-daily pill that can help protect HIV-negative partners from HIV. To the best of your knowledge, are any of your HIV-negative sex partner(s) prescribed PrEP?",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-26-0",
+            "display": "Yes, all are"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-26-1",
+            "display": "Some are"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-26-2",
+            "display": "No, none are"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-26-3",
+            "display": "I don't know"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-27",
+      "text": "Would you like information on PrEP?",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-27-0",
+            "display": "Yes"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-27-1",
+            "display": "No"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-28",
+      "text": "In the past 3 months, with your HIV%(srbiPartnerHIVStatusEN) partners, have you given oral sex without a condom or barrier protection? By oral sex, we mean when a mouth touches someone's genitals.",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-28-0",
+            "display": "Yes"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-28-1",
+            "display": "No"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-28-2",
+            "display": "Can't remember"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-29",
+      "text": "In the past 3 months, with your HIV%(srbiPartnerHIVStatusEN) partners, have you received oral sex without a condom or barrier protection? By oral sex, we mean when a mouth touches someone's genitals.",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-29-0",
+            "display": "Yes"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-29-1",
+            "display": "No"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-29-2",
+            "display": "Can't remember"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-30",
+      "text": "In the past 3 months, with your HIV%(srbiPartnerHIVStatusEN) partners, have you had anal sex without condoms%(srbiSexInsertiveText)? By this we mean %(srbiInsertPenisText) entering an anus (butt)%(srbiMultiplePartnersAnalSexTopText).",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-30-0",
+            "display": "Yes"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-30-1",
+            "display": "No"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-30-2",
+            "display": "Can't remember"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-31",
+      "text": "In the past 3 months, with your HIV%(srbiPartnerHIVStatusEN) partners, have you had anal sex without condoms%(srbiSexReceptiveText)? By this we mean %(srbiReceptivePenisText) entering your anus (butt)%(srbiMultiplePartnersAnalSexBottomText).",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-31-0",
+            "display": "Yes"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-31-1",
+            "display": "No"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-31-2",
+            "display": "Can't remember"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-32",
+      "text": "In the past 3 months, with your HIV%(srbiPartnerHIVStatusEN) partners, have you had vaginal sex without condoms%(srbiSexReceptiveText)? By this we mean %(srbiReceptivePenisText) entering %(srbiVaginalText).",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-32-0",
+            "display": "Yes"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-32-1",
+            "display": "No"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-32-2",
+            "display": "Can't remember"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-33",
+      "text": "In the past 3 months, with your HIV%(srbiPartnerHIVStatusEN) partners, have you had vaginal sex without condoms%(srbiSexInsertiveText)? By this we mean %(srbiInsertPenisText) entering %(srbiPartnerVaginalText).",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-33-0",
+            "display": "Yes"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-33-1",
+            "display": "No"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-33-2",
+            "display": "Can't remember"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-34",
+      "text": "In the past 3 months, with your HIV%(srbiPartnerHIVStatusEN) partners, have you had vaginal/frontal sex without %(srbiBarrierBirthControlEN)? By vaginal sex, we mean a penis entering a vagina.",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-34-0",
+            "display": "Yes"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-34-1",
+            "display": "No"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-34-2",
+            "display": "Can't remember"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-35",
+      "text": "In the past 3 months, with your HIV%(srbiPartnerHIVStatusEN) partners, have you had anal sex without a condom? By anal sex, we mean a penis entering an anus (butt).",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-35-0",
+            "display": "Yes"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-35-1",
+            "display": "No"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-35-2",
+            "display": "Can't remember"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-36",
+      "text": "In the past 3 months, with your HIV%(srbiPartnerHIVStatusEN) partners, have you had oral sex without a condom or barrier protection? By oral sex, we mean when a mouth touches someone's genitals.",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-36-0",
+            "display": "Yes"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-36-1",
+            "display": "No"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-36-2",
+            "display": "Can't remember"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-37",
+      "text": "In the past 3 months, thinking about the times you had anal sex without condoms, please mark on the line how often you were the \"bottom\" (receiving partner)",
+      "type": "integer"
+    },
+    {
+      "linkId": "SEXUAL-RISK-38",
+      "text": "In the past 3 months, have you been concerned that you may have been exposed to HIV or another kind of sexually transmitted infection (STI)?",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-38-0",
+            "display": "Yes"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-38-1",
+            "display": "No"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-39",
+      "text": "In the past 3 months, have you been concerned that you may have been exposed to a sexually transmitted infection (STI) or re-exposed to HIV?",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-39-0",
+            "display": "Yes"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "SEXUAL-RISK-39-1",
+            "display": "No"
           }
         }
       ]
@@ -100,294 +1049,6 @@
           "valueExpression": {
             "language": "text/fhirpath",
             "expression": "iif(%resource.item.where(linkId='SEXUAL-RISK-0').answer.empty(), null, %resource.item.where(linkId='SEXUAL-RISK-0').answer.valueCoding.extension('http://hl7.org/fhir/StructureDefinition/ordinalValue').valueDecimal.toInteger())"
-          }
-        }
-      ]
-    },
-    {
-      "linkId": "SEXUAL-RISK-1",
-      "text": "How many drinks containing alcohol do you have on a typical day when you are drinking?",
-      "type": "choice",
-      "answerOption": [
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-1-0",
-            "display": "1",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 0
-                }
-            ]
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-1-1",
-            "display": "2",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 0
-                }
-            ]
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-1-2",
-            "display": "3",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 1
-                }
-            ]
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-1-3",
-            "display": "4",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 1
-                }
-            ]
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-1-4",
-            "display": "5",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 2
-                }
-            ]
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-1-5",
-            "display": "6",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 2 
-                }
-            ]
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-1-6",
-            "display": "7",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 3 
-                }
-            ]
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-1-7",
-            "display": "8",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 3 
-                }
-            ]
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-1-8",
-            "display": "9",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 3 
-                }
-            ]
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-1-9",
-            "display": "10 or more",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 4 
-                }
-            ]
-          }
-        }
-      ],
-      "extension": [
-        {
-          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
-          "valueExpression": {
-            "language": "text/fhirpath",
-            "expression": "%resource.item.where(linkId='SEXUAL-RISK-0').answer.valueCoding.code != 'SEXUAL-RISK-0-0'"
-          }
-        }
-      ]
-    },
-    {
-      "linkId": "SEXUAL-RISK-2-not-male",
-      "text": "How often do you have four or more drinks on one occasion?",
-      "type": "choice",
-      "answerOption": [
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-2-not-male-0",
-            "display": "Never",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 0 
-                }
-            ]
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-2-not-male-1",
-            "display": "Less than monthly",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 1
-                }
-            ]
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-2-not-male-2",
-            "display": "Monthly",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 2
-                }
-            ]
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-2-not-male-3",
-            "display": "Weekly",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 3
-                }
-            ]
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-2-not-male-4",
-            "display": "Daily or almost daily",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 4
-                }
-            ]
-          }
-        }
-      ],
-      "extension": [
-        {
-          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
-          "valueExpression": {
-            "language": "text/fhirpath",
-            "expression": "((%patient.gender != 'male') or %patient.gender.exists() != true) and %resource.item.where(linkId='SEXUAL-RISK-0').answer.valueCoding.code != 'SEXUAL-RISK-0-0'"
-          }
-        }
-      ]
-    },
-    {
-      "linkId": "SEXUAL-RISK-2-male",
-      "text": "How often do you have five or more drinks on one occasion?",
-      "type": "choice",
-      "answerOption": [
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-2-male-0",
-            "display": "Never",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 0
-                }
-            ]
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-2-male-1",
-            "display": "Less than monthly",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 1
-                }
-            ]
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-2-male-2",
-            "display": "Monthly",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 2
-                }
-            ]
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-2-male-3",
-            "display": "Weekly",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 3 
-                }
-            ]
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-2-male-4",
-            "display": "Daily or almost daily",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 4 
-                }
-            ]
-          }
-        }
-      ],
-      "extension": [
-        {
-          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
-          "valueExpression": {
-            "language": "text/fhirpath",
-            "expression": "%patient.gender.exists() and (%patient.gender = 'male') and (%resource.item.where(linkId='SEXUAL-RISK-0').answer.valueCoding.code != 'SEXUAL-RISK-0-0')"
           }
         }
       ]
@@ -448,490 +1109,6 @@
           "valueExpression": {
             "language": "text/fhirpath",
             "expression": "iif(%patient.gender = 'male' and %resource.item.where(linkId='SEXUAL-RISK-C-score').answer.valueDecimal.toInteger() >= 4, 'At-risk', iif(%patient.gender != 'male' and %resource.item.where(linkId='SEXUAL-RISK-C-score').answer.valueDecimal.toInteger() >= 3, 'At-risk', iif((%resource.item.where(linkId='SEXUAL-RISK-C-score').answer.empty() != true), 'Not at-risk', null)))"
-          }
-        }
-      ]
-    },
-    {
-      "linkId": "SEXUAL-RISK-3",
-      "text": "How often during the past 12 months have you found that you were not able to stop drinking once you had started?",
-      "type": "choice",
-      "answerOption": [
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-3-0",
-            "display": "Never",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 0
-                }
-            ]
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-3-1",
-            "display": "Less than monthly",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 1
-                }
-            ]
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-3-2",
-            "display": "Monthly",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 2
-                }
-            ]
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-3-3",
-            "display": "Weekly",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 3 
-                }
-            ]
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-3-4",
-            "display": "Daily or almost daily",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 4 
-                }
-            ]
-          }
-        }
-      ],
-      "extension": [
-        {
-          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
-          "valueExpression": {
-            "language": "text/fhirpath",
-            "expression": "(%resource.item.where(linkId='SEXUAL-RISK-0').answer.valueCoding.code != 'SEXUAL-RISK-0-0' and (iif(%patient.gender = 'male' and %resource.item.where(linkId='SEXUAL-RISK-C-score').answer.valueDecimal.toInteger() >= 4, true, iif(%patient.gender != 'male' and %resource.item.where(linkId='SEXUAL-RISK-C-score').answer.valueDecimal.toInteger() >= 3), true, false)))"
-          }
-        }
-      ]
-    },
-    {
-      "linkId": "SEXUAL-RISK-4",
-      "text": "How often during the past 12 months have you failed to do what was normally expected from you because of drinking?",
-      "type": "choice",
-      "answerOption": [
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-4-0",
-            "display": "Never",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 0
-                }
-            ]
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-4-1",
-            "display": "Less than monthly",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 1
-                }
-            ]
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-4-2",
-            "display": "Monthly",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 2
-                }
-            ]
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-4-3",
-            "display": "Weekly",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 3 
-                }
-            ]
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-4-4",
-            "display": "Daily or almost daily",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 4 
-                }
-            ]
-          }
-        }
-      ],
-      "extension": [
-        {
-          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
-          "valueExpression": {
-            "language": "text/fhirpath",
-            "expression": "(%resource.item.where(linkId='SEXUAL-RISK-0').answer.valueCoding.code != 'SEXUAL-RISK-0-0' and (iif(%patient.gender = 'male' and %resource.item.where(linkId='SEXUAL-RISK-C-score').answer.valueDecimal.toInteger() >= 4, true, iif(%patient.gender != 'male' and %resource.item.where(linkId='SEXUAL-RISK-C-score').answer.valueDecimal.toInteger() >= 3), true, false)))"
-          }
-        }
-      ]
-    },
-    {
-      "linkId": "SEXUAL-RISK-5",
-      "text": "How often during the past 12 months have you needed a first drink in the morning to get yourself going after a heavy drinking session?",
-      "type": "choice",
-      "answerOption": [
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-5-0",
-            "display": "Never",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 0
-                }
-            ]
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-5-1",
-            "display": "Less than monthly",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 1
-                }
-            ]
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-5-2",
-            "display": "Monthly",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 2
-                }
-            ]
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-5-3",
-            "display": "Weekly",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 3 
-                }
-            ]
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-5-4",
-            "display": "Daily or almost daily",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 4 
-                }
-            ]
-          }
-        }
-      ],
-      "extension": [
-        {
-          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
-          "valueExpression": {
-            "language": "text/fhirpath",
-            "expression": "(%resource.item.where(linkId='SEXUAL-RISK-0').answer.valueCoding.code != 'SEXUAL-RISK-0-0' and (iif(%patient.gender = 'male' and %resource.item.where(linkId='SEXUAL-RISK-C-score').answer.valueDecimal.toInteger() >= 4, true, iif(%patient.gender != 'male' and %resource.item.where(linkId='SEXUAL-RISK-C-score').answer.valueDecimal.toInteger() >= 3), true, false)))"
-          }
-        }
-      ]
-    },
-    {
-      "linkId": "SEXUAL-RISK-6",
-      "text": "How often during the past 12 months have you had a feeling of guilt or remorse after drinking?",
-      "type": "choice",
-      "answerOption": [
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-6-0",
-            "display": "Never",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 0
-                }
-            ]
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-6-1",
-            "display": "Less than monthly",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 1
-                }
-            ]
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-6-2",
-            "display": "Monthly",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 2
-                }
-            ]
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-6-3",
-            "display": "Weekly",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 3 
-                }
-            ]
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-6-4",
-            "display": "Daily or almost daily",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 4 
-                }
-            ]
-          }
-        }
-      ],
-      "extension": [
-        {
-          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
-          "valueExpression": {
-            "language": "text/fhirpath",
-            "expression": "(%resource.item.where(linkId='SEXUAL-RISK-0').answer.valueCoding.code != 'SEXUAL-RISK-0-0' and (iif(%patient.gender = 'male' and %resource.item.where(linkId='SEXUAL-RISK-C-score').answer.valueDecimal.toInteger() >= 4, true, iif(%patient.gender != 'male' and %resource.item.where(linkId='SEXUAL-RISK-C-score').answer.valueDecimal.toInteger() >= 3), true, false)))"
-          }
-        }
-      ]
-    },
-    {
-      "linkId": "SEXUAL-RISK-7",
-      "text": "How often during the past 12 months have you been unable to remember what happened the night before because you had been drinking?",
-      "type": "choice",
-      "answerOption": [
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-7-0",
-            "display": "Never",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 0
-                }
-            ]
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-7-1",
-            "display": "Less than monthly",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 1
-                }
-            ]
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-7-2",
-            "display": "Monthly",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 2
-                }
-            ]
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-7-3",
-            "display": "Weekly",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 3 
-                }
-            ]
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-7-4",
-            "display": "Daily or almost daily",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 4 
-                }
-            ]
-          }
-        }
-      ],
-      "extension": [
-        {
-          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
-          "valueExpression": {
-            "language": "text/fhirpath",
-            "expression": "(%resource.item.where(linkId='SEXUAL-RISK-0').answer.valueCoding.code != 'SEXUAL-RISK-0-0' and (iif(%patient.gender = 'male' and %resource.item.where(linkId='SEXUAL-RISK-C-score').answer.valueDecimal.toInteger() >= 4, true, iif(%patient.gender != 'male' and %resource.item.where(linkId='SEXUAL-RISK-C-score').answer.valueDecimal.toInteger() >= 3), true, false)))"
-          }
-        }
-      ]
-    },
-    {
-      "linkId": "SEXUAL-RISK-8",
-      "text": "Have you or someone else been injured as a result of your drinking?",
-      "type": "choice",
-      "answerOption": [
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-8-0",
-            "display": "No",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 0 
-                }
-            ]
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-8-1",
-            "display": "Yes, but not in the last 12 months",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 2
-                }
-            ]
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-8-2",
-            "display": "Yes, during last 12 months",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 4
-                }
-            ]
-          }
-        }
-      ],
-      "extension": [
-        {
-          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
-          "valueExpression": {
-            "language": "text/fhirpath",
-            "expression": "(%resource.item.where(linkId='SEXUAL-RISK-0').answer.valueCoding.code != 'SEXUAL-RISK-0-0' and (iif(%patient.gender = 'male' and %resource.item.where(linkId='SEXUAL-RISK-C-score').answer.valueDecimal.toInteger() >= 4, true, iif(%patient.gender != 'male' and %resource.item.where(linkId='SEXUAL-RISK-C-score').answer.valueDecimal.toInteger() >= 3), true, false)))"
-          }
-        }
-      ]
-    },
-    {
-      "linkId": "SEXUAL-RISK-9",
-      "text": "Has a relative or friend or a doctor or another health worker been concerned about your drinking or suggested you cut down?",
-      "type": "choice",
-      "answerOption": [
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-9-0",
-            "display": "No",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 0 
-                }
-            ]
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-9-1",
-            "display": "Yes, but not in the last 12 months",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 2 
-                }
-            ]
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "SEXUAL-RISK-9-2",
-            "display": "Yes, during last 12 months",
-            "extension": [
-                {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 4
-                }
-            ]
-          }
-        }
-      ],
-      "extension": [
-        {
-          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
-          "valueExpression": {
-            "language": "text/fhirpath",
-            "expression": "(%resource.item.where(linkId='SEXUAL-RISK-0').answer.valueCoding.code != 'SEXUAL-RISK-0-0' and (iif(%patient.gender = 'male' and %resource.item.where(linkId='SEXUAL-RISK-C-score').answer.valueDecimal.toInteger() >= 4, true, iif(%patient.gender != 'male' and %resource.item.where(linkId='SEXUAL-RISK-C-score').answer.valueDecimal.toInteger() >= 3), true, false)))"
           }
         }
       ]

--- a/CIRG-CNICS-SEXUAL-RISK.json
+++ b/CIRG-CNICS-SEXUAL-RISK.json
@@ -431,7 +431,20 @@
     {
       "linkId": "SEXUAL-RISK-15",
       "text": "In the past 3 months, thinking about the times you had anal sex without condoms, please mark on the line how often you were the \"bottom\" (receiving partner).",
-      "type": "integer"
+      "type": "integer",
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/ValueSet/questionnaire-item-control",
+                "code": "slider"
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "linkId": "SEXUAL-RISK-16",
@@ -998,7 +1011,20 @@
     {
       "linkId": "SEXUAL-RISK-37",
       "text": "In the past 3 months, thinking about the times you had anal sex without condoms, please mark on the line how often you were the \"bottom\" (receiving partner)",
-      "type": "integer"
+      "type": "integer",
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/ValueSet/questionnaire-item-control",
+                "code": "slider"
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "linkId": "SEXUAL-RISK-38",

--- a/CIRG-CNICS-SEXUAL-RISK.json
+++ b/CIRG-CNICS-SEXUAL-RISK.json
@@ -1179,7 +1179,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
           "valueExpression": {
             "language": "text/fhirpath",
-            "expression": "iif((%resource.item.where(linkId='SEXUAL-RISK-SCORE-UNPROTECTED-ANAL').answer.valueString.toString = 'Yes' or %resource.item.where(linkId='SEXUAL-RISK-SCORE-UNPROTECTED-ORAL').answer.valueString.toString = 'Yes' or %resource.item.where(linkId='SEXUAL-RISK-SCORE-UNPROTECTED-VAGINAL').answer.valueString.toString = 'Yes'),'Yes',iif((%resource.item.where(linkId='SEXUAL-RISK-SCORE-UNPROTECTED-ANAL').answer.valueString.toString = 'I can\\'t remember' or %resource.item.where(linkId='SEXUAL-RISK-SCORE-UNPROTECTED-ORAL').answer.valueString.toString = 'I can\\'t remember' or %resource.item.where(linkId='SEXUAL-RISK-SCORE-UNPROTECTED-VAGINAL').answer.valueString.toString = 'I can\\'t remember'),'I can\\'t remember','No'))"
+            "expression": "iif((%resource.item.where(linkId='SEXUAL-RISK-SCORE-UNPROTECTED-ANAL').answer.valueString.toString() = 'Yes' or %resource.item.where(linkId='SEXUAL-RISK-SCORE-UNPROTECTED-ORAL').answer.valueString.toString() = 'Yes' or %resource.item.where(linkId='SEXUAL-RISK-SCORE-UNPROTECTED-VAGINAL').answer.valueString.toString() = 'Yes'),'Yes',iif((%resource.item.where(linkId='SEXUAL-RISK-SCORE-UNPROTECTED-ANAL').answer.valueString.toString() = 'I can\\'t remember' or %resource.item.where(linkId='SEXUAL-RISK-SCORE-UNPROTECTED-ORAL').answer.valueString.toString() = 'I can\\'t remember' or %resource.item.where(linkId='SEXUAL-RISK-SCORE-UNPROTECTED-VAGINAL').answer.valueString.toString() = 'I can\\'t remember'),'I can\\'t remember','No'))"
           }
         }
       ]

--- a/CIRG-CNICS-SEXUAL-RISK.json
+++ b/CIRG-CNICS-SEXUAL-RISK.json
@@ -1185,7 +1185,7 @@
       ]
     },
     {
-      "linkId": "SEXUAL-RISK-SCORE-STI-EXPOSURE-fhirpath",
+      "linkId": "SEXUAL-RISK-SCORE-STI-EXPOSURE",
       "text": "Whether the patient is concerned for STI exposure. If this is true, it should be flagged as critical.",
       "type": "boolean",
       "readOnly": true,

--- a/CIRG-CNICS-SEXUAL-RISK.json
+++ b/CIRG-CNICS-SEXUAL-RISK.json
@@ -1010,7 +1010,7 @@
     },
     {
       "linkId": "SEXUAL-RISK-37",
-      "text": "In the past 3 months, thinking about the times you had anal sex without condoms, please mark on the line how often you were the \"bottom\" (receiving partner)",
+      "text": "In the past 3 months, thinking about the times you had anal sex without condoms, please mark on the line how often you were the \"bottom\" (receiving partner).",
       "type": "integer",
       "extension": [
         {
@@ -1112,14 +1112,14 @@
     {
       "linkId": "SEXUAL-RISK-SCORE-UNPROTECTED-ANAL",
       "text": "Whether the patient had unprotected anal sex. This is for internal scoring purposes only.",
-      "type": "boolean",
+      "type": "string",
       "readOnly": true,
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
           "valueExpression": {
             "language": "text/fhirpath",
-            "expression": "iif(%resource.item.where(linkId='SEXUAL-RISK-0').answer.empty(), 'Not answered', %resource.item.where(linkId='SEXUAL-RISK-0').answer.valueCoding.display)"
+            "expression": "iif((%resource.item.where(linkId='SEXUAL-RISK-8').answer.valueCoding.code = 'SEXUAL-RISK-8-0') or (%resource.item.where(linkId='SEXUAL-RISK-9').answer.valueCoding.code = 'SEXUAL-RISK-9-0') or(%resource.item.where(linkId='SEXUAL-RISK-13').answer.valueCoding.code = 'SEXUAL-RISK-13-0') or(%resource.item.where(linkId='SEXUAL-RISK-30').answer.valueCoding.code = 'SEXUAL-RISK-30-0') or(%resource.item.where(linkId='SEXUAL-RISK-31').answer.valueCoding.code = 'SEXUAL-RISK-31-0') or(%resource.item.where(linkId='SEXUAL-RISK-35').answer.valueCoding.code = 'SEXUAL-RISK-35-0'),'Yes', iif((%resource.item.where(linkId='SEXUAL-RISK-8').answer.valueCoding.code = 'SEXUAL-RISK-8-2') or (%resource.item.where(linkId='SEXUAL-RISK-9').answer.valueCoding.code = 'SEXUAL-RISK-9-2') or(%resource.item.where(linkId='SEXUAL-RISK-13').answer.valueCoding.code = 'SEXUAL-RISK-13-2') or(%resource.item.where(linkId='SEXUAL-RISK-30').answer.valueCoding.code = 'SEXUAL-RISK-30-2') or(%resource.item.where(linkId='SEXUAL-RISK-31').answer.valueCoding.code = 'SEXUAL-RISK-31-2') or(%resource.item.where(linkId='SEXUAL-RISK-35').answer.valueCoding.code = 'SEXUAL-RISK-35-2'),'I can\\'t remember',iif((%resource.item.where(linkId='SEXUAL-RISK-8').answer.valueCoding.code = 'SEXUAL-RISK-8-1') or (%resource.item.where(linkId='SEXUAL-RISK-9').answer.valueCoding.code = 'SEXUAL-RISK-9-1') or(%resource.item.where(linkId='SEXUAL-RISK-13').answer.valueCoding.code = 'SEXUAL-RISK-13-1') or(%resource.item.where(linkId='SEXUAL-RISK-30').answer.valueCoding.code = 'SEXUAL-RISK-30-1') or(%resource.item.where(linkId='SEXUAL-RISK-31').answer.valueCoding.code = 'SEXUAL-RISK-31-1') or(%resource.item.where(linkId='SEXUAL-RISK-35').answer.valueCoding.code = 'SEXUAL-RISK-35-1'),'No','')))"
           }
         }
       ]
@@ -1142,14 +1142,14 @@
     {
       "linkId": "SEXUAL-RISK-SCORE-UNPROTECTED-ORAL",
       "text": "Whether the patient had unprotected oral sex. This is for internal scoring purposes only.",
-      "type": "boolean",
+      "type": "string",
       "readOnly": true,
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
           "valueExpression": {
             "language": "text/fhirpath",
-            "expression": ""
+            "expression": "iif((%resource.item.where(linkId='SEXUAL-RISK-6').answer.valueCoding.code = 'SEXUAL-RISK-6-0') or (%resource.item.where(linkId='SEXUAL-RISK-7').answer.valueCoding.code = 'SEXUAL-RISK-7-0') or(%resource.item.where(linkId='SEXUAL-RISK-14').answer.valueCoding.code = 'SEXUAL-RISK-14-0') or(%resource.item.where(linkId='SEXUAL-RISK-28').answer.valueCoding.code = 'SEXUAL-RISK-28-0') or(%resource.item.where(linkId='SEXUAL-RISK-29').answer.valueCoding.code = 'SEXUAL-RISK-29-0') or(%resource.item.where(linkId='SEXUAL-RISK-36').answer.valueCoding.code = 'SEXUAL-RISK-36-0'),'Yes', iif((%resource.item.where(linkId='SEXUAL-RISK-6').answer.valueCoding.code = 'SEXUAL-RISK-6-2') or (%resource.item.where(linkId='SEXUAL-RISK-7').answer.valueCoding.code = 'SEXUAL-RISK-7-2') or(%resource.item.where(linkId='SEXUAL-RISK-14').answer.valueCoding.code = 'SEXUAL-RISK-14-2') or(%resource.item.where(linkId='SEXUAL-RISK-28').answer.valueCoding.code = 'SEXUAL-RISK-28-2') or(%resource.item.where(linkId='SEXUAL-RISK-29').answer.valueCoding.code = 'SEXUAL-RISK-29-2') or(%resource.item.where(linkId='SEXUAL-RISK-36').answer.valueCoding.code = 'SEXUAL-RISK-36-2'),'I can\\'t remember',iif((%resource.item.where(linkId='SEXUAL-RISK-6').answer.valueCoding.code = 'SEXUAL-RISK-6-1') or (%resource.item.where(linkId='SEXUAL-RISK-7').answer.valueCoding.code = 'SEXUAL-RISK-7-1') or(%resource.item.where(linkId='SEXUAL-RISK-14').answer.valueCoding.code = 'SEXUAL-RISK-14-1') or(%resource.item.where(linkId='SEXUAL-RISK-28').answer.valueCoding.code = 'SEXUAL-RISK-28-1') or(%resource.item.where(linkId='SEXUAL-RISK-29').answer.valueCoding.code = 'SEXUAL-RISK-29-1') or(%resource.item.where(linkId='SEXUAL-RISK-36').answer.valueCoding.code = 'SEXUAL-RISK-36-1'),'No','')))"
           }
         }
       ]
@@ -1157,14 +1157,14 @@
     {
       "linkId": "SEXUAL-RISK-SCORE-UNPROTECTED-VAGINAL",
       "text": "Whether the patient had unprotected vaginal sex. This is for internal scoring purposes only.",
-      "type": "boolean",
+      "type": "string",
       "readOnly": true,
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
           "valueExpression": {
             "language": "text/fhirpath",
-            "expression": ""
+            "expression": "iif((%resource.item.where(linkId='SEXUAL-RISK-10').answer.valueCoding.code = 'SEXUAL-RISK-10-0') or (%resource.item.where(linkId='SEXUAL-RISK-11').answer.valueCoding.code = 'SEXUAL-RISK-11-0') or(%resource.item.where(linkId='SEXUAL-RISK-12').answer.valueCoding.code = 'SEXUAL-RISK-12-0') or(%resource.item.where(linkId='SEXUAL-RISK-32').answer.valueCoding.code = 'SEXUAL-RISK-32-0') or(%resource.item.where(linkId='SEXUAL-RISK-33').answer.valueCoding.code = 'SEXUAL-RISK-33-0') or(%resource.item.where(linkId='SEXUAL-RISK-34').answer.valueCoding.code = 'SEXUAL-RISK-34-0'),'Yes', iif((%resource.item.where(linkId='SEXUAL-RISK-10').answer.valueCoding.code = 'SEXUAL-RISK-10-2') or (%resource.item.where(linkId='SEXUAL-RISK-11').answer.valueCoding.code = 'SEXUAL-RISK-11-2') or(%resource.item.where(linkId='SEXUAL-RISK-12').answer.valueCoding.code = 'SEXUAL-RISK-12-2') or(%resource.item.where(linkId='SEXUAL-RISK-32').answer.valueCoding.code = 'SEXUAL-RISK-32-2') or(%resource.item.where(linkId='SEXUAL-RISK-33').answer.valueCoding.code = 'SEXUAL-RISK-33-2') or(%resource.item.where(linkId='SEXUAL-RISK-34').answer.valueCoding.code = 'SEXUAL-RISK-34-2'),'I can\\'t remember',iif((%resource.item.where(linkId='SEXUAL-RISK-10').answer.valueCoding.code = 'SEXUAL-RISK-10-1') or (%resource.item.where(linkId='SEXUAL-RISK-11').answer.valueCoding.code = 'SEXUAL-RISK-11-1') or(%resource.item.where(linkId='SEXUAL-RISK-12').answer.valueCoding.code = 'SEXUAL-RISK-12-1') or(%resource.item.where(linkId='SEXUAL-RISK-32').answer.valueCoding.code = 'SEXUAL-RISK-32-1') or(%resource.item.where(linkId='SEXUAL-RISK-33').answer.valueCoding.code = 'SEXUAL-RISK-33-1') or(%resource.item.where(linkId='SEXUAL-RISK-34').answer.valueCoding.code = 'SEXUAL-RISK-34-1'),'No','')))"
           }
         }
       ]
@@ -1172,20 +1172,20 @@
     {
       "linkId": "SEXUAL-RISK-SCORE-UNPROTECTED",
       "text": "Whether the patient had unprotected sex of any type.",
-      "type": "boolean",
+      "type": "string",
       "readOnly": true,
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
           "valueExpression": {
             "language": "text/fhirpath",
-            "expression": ""
+            "expression": "'TBD'"
           }
         }
       ]
     },
     {
-      "linkId": "SEXUAL-RISK-SCORE-STI-EXPOSURE",
+      "linkId": "SEXUAL-RISK-SCORE-STI-EXPOSURE-FIXME-fhirpath",
       "text": "Whether the patient is concerned for STI exposure. If this is true, it should be flagged as critical.",
       "type": "boolean",
       "readOnly": true,
@@ -1194,157 +1194,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
           "valueExpression": {
             "language": "text/fhirpath",
-            "expression": ""
-          }
-        }
-      ]
-    },
-    {
-      "linkId": "SEXUAL-RISK-Q1-Q2-score",
-      "text": "Score contribution from Q1 & Q2. This is an internal item for other scores' calculations.",
-      "type": "decimal",
-      "readOnly": true,
-      "extension": [
-        {
-          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
-          "valueExpression": {
-            "language": "text/fhirpath",
-            "expression": "(iif(%resource.item.where(linkId='SEXUAL-RISK-1').answer.empty(), 0, %resource.item.where(linkId='SEXUAL-RISK-1').answer.valueCoding.extension('http://hl7.org/fhir/StructureDefinition/ordinalValue').valueDecimal.toInteger()) + iif(%resource.item.where(linkId='SEXUAL-RISK-2-not-male').answer.empty(), 0, %resource.item.where(linkId='SEXUAL-RISK-2-not-male').answer.valueCoding.extension('http://hl7.org/fhir/StructureDefinition/ordinalValue').valueDecimal.toInteger()) + iif(%resource.item.where(linkId='SEXUAL-RISK-2-male').answer.empty(), 0, %resource.item.where(linkId='SEXUAL-RISK-2-male').answer.valueCoding.extension('http://hl7.org/fhir/StructureDefinition/ordinalValue').valueDecimal.toInteger()))"
-          }
-        }
-      ]
-    },
-    {
-      "linkId": "SEXUAL-RISK-C-complete",
-      "text": "SEXUAL-RISK-C part of questionnaire (first three questions) complete. This is an internal item for other scores' calculations.",
-      "type": "boolean",
-      "readOnly": true,
-      "extension": [
-        {
-          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
-          "valueExpression": {
-            "language": "text/fhirpath",
-            "expression": "%resource.item.where(linkId = 'SEXUAL-RISK-0').answer.valueCoding.code.exists() and (%resource.item.where(linkId = 'SEXUAL-RISK-0').answer.valueCoding.code = 'SEXUAL-RISK-0-0') or (%resource.item.where(linkId = 'SEXUAL-RISK-1').answer.valueCoding.code.exists() and (%resource.item.where(linkId = 'SEXUAL-RISK-2-not-male').answer.valueCoding.code.exists() or %resource.item.where(linkId = 'SEXUAL-RISK-2-male').answer.valueCoding.code.exists()))"
-          }
-        }
-      ]
-    },
-    {
-      "linkId": "SEXUAL-RISK-C-score",
-      "text": "SEXUAL-RISK-C score (score for questions 0-2)",
-      "type": "decimal",
-      "readOnly": true,
-      "extension": [
-        {
-          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
-          "valueExpression": {
-            "language": "text/fhirpath",
-            "expression": "%resource.item.where(linkId='SEXUAL-RISK-Q0-score').answer.valueDecimal.toInteger() + %resource.item.where(linkId='SEXUAL-RISK-Q1-Q2-score').answer.valueDecimal.toInteger()"
-          }
-        }
-      ]
-    },
-    {
-      "linkId": "SEXUAL-RISK-C-score-interpretation",
-      "text": "CNICS SEXUAL-RISK-C score interpretation",
-      "type": "string",
-      "readOnly": true,
-      "extension": [
-        {
-          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
-          "valueExpression": {
-            "language": "text/fhirpath",
-            "expression": "iif(%patient.gender = 'male' and %resource.item.where(linkId='SEXUAL-RISK-C-score').answer.valueDecimal.toInteger() >= 4, 'At-risk', iif(%patient.gender != 'male' and %resource.item.where(linkId='SEXUAL-RISK-C-score').answer.valueDecimal.toInteger() >= 3, 'At-risk', iif((%resource.item.where(linkId='SEXUAL-RISK-C-score').answer.empty() != true), 'Not at-risk', null)))"
-          }
-        }
-      ]
-    },
-    {
-      "linkId": "SEXUAL-RISK-last-7-any-answers",
-      "text": "At least one of the last 7 questions has been answered. This is an internal item for other scores' calculations.",
-      "type": "boolean",
-      "readOnly": true,
-      "extension": [
-        {
-          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
-          "valueExpression": {
-            "language": "text/fhirpath",
-            "expression": "%resource.item.where(linkId = 'SEXUAL-RISK-3').answer.valueCoding.code.exists() or %resource.item.where(linkId = 'SEXUAL-RISK-4').answer.valueCoding.code.exists() or %resource.item.where(linkId = 'SEXUAL-RISK-5').answer.valueCoding.code.exists() or %resource.item.where(linkId = 'SEXUAL-RISK-6').answer.valueCoding.code.exists() or %resource.item.where(linkId = 'SEXUAL-RISK-7').answer.valueCoding.code.exists() or %resource.item.where(linkId = 'SEXUAL-RISK-8').answer.valueCoding.code.exists() or %resource.item.where(linkId = 'SEXUAL-RISK-9').answer.valueCoding.code.exists()"
-          }
-        }
-      ]
-    },
-    {
-      "linkId": "SEXUAL-RISK-last-7-complete",
-      "text": "Last 7 questions here have been answered. This is an internal item for other scores' calculations.",
-      "type": "boolean",
-      "readOnly": true,
-      "extension": [
-        {
-          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
-          "valueExpression": {
-            "language": "text/fhirpath",
-            "expression": "%resource.item.where(linkId = 'SEXUAL-RISK-3').answer.valueCoding.code.exists() and %resource.item.where(linkId = 'SEXUAL-RISK-4').answer.valueCoding.code.exists() and %resource.item.where(linkId = 'SEXUAL-RISK-5').answer.valueCoding.code.exists() and %resource.item.where(linkId = 'SEXUAL-RISK-6').answer.valueCoding.code.exists() and %resource.item.where(linkId = 'SEXUAL-RISK-7').answer.valueCoding.code.exists() and %resource.item.where(linkId = 'SEXUAL-RISK-8').answer.valueCoding.code.exists() and %resource.item.where(linkId = 'SEXUAL-RISK-9').answer.valueCoding.code.exists()"
-          }
-        }
-      ]
-    },
-    {
-      "linkId": "SEXUAL-RISK-complete",
-      "text": "SEXUAL-RISK questionnaire complete",
-      "type": "boolean",
-      "readOnly": true,
-      "extension": [
-        {
-          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
-          "valueExpression": {
-            "language": "text/fhirpath",
-            "expression": "(%resource.item.where(linkId='SEXUAL-RISK-C-complete').answer.valueBoolean.toBoolean() = true and (iif((%resource.item.where(linkId='SEXUAL-RISK-C-score').answer.valueDecimal.toInteger() >= 4 and (%patient.gender = 'male')) and %resource.item.where(linkId='SEXUAL-RISK-last-7-complete').answer.valueBoolean.toBoolean() = true, true,   (iif((%resource.item.where(linkId='SEXUAL-RISK-C-score').answer.valueDecimal.toInteger() >= 3 and (%patient.gender != 'male')) and %resource.item.where(linkId='SEXUAL-RISK-last-7-complete').answer.valueBoolean.toBoolean() = true, true, false)))))"
-          }
-        }
-      ]
-    },
-    {
-      "linkId": "SEXUAL-RISK-score",
-      "text": "CNICS SEXUAL-RISK score",
-      "type": "decimal",
-      "readOnly": true,
-      "extension": [
-        {
-          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
-          "valueExpression": {
-            "language": "text/fhirpath",
-            "expression": "(%resource.item.where(linkId='SEXUAL-RISK-Q0-score').answer.valueDecimal.toInteger() + %resource.item.where(linkId='SEXUAL-RISK-Q1-Q2-score').answer.valueDecimal.toInteger() + iif(%resource.item.where(linkId='SEXUAL-RISK-3').answer.empty(), 0, %resource.item.where(linkId='SEXUAL-RISK-3').answer.valueCoding.extension('http://hl7.org/fhir/StructureDefinition/ordinalValue').valueDecimal.toInteger()) + iif(%resource.item.where(linkId='SEXUAL-RISK-4').answer.empty(), 0, %resource.item.where(linkId='SEXUAL-RISK-4').answer.valueCoding.extension('http://hl7.org/fhir/StructureDefinition/ordinalValue').valueDecimal.toInteger()) + iif(%resource.item.where(linkId='SEXUAL-RISK-5').answer.empty(), 0, %resource.item.where(linkId='SEXUAL-RISK-5').answer.valueCoding.extension('http://hl7.org/fhir/StructureDefinition/ordinalValue').valueDecimal.toInteger()) + iif(%resource.item.where(linkId='SEXUAL-RISK-6').answer.empty(), 0, %resource.item.where(linkId='SEXUAL-RISK-6').answer.valueCoding.extension('http://hl7.org/fhir/StructureDefinition/ordinalValue').valueDecimal.toInteger()) + iif(%resource.item.where(linkId='SEXUAL-RISK-7').answer.empty(), 0, %resource.item.where(linkId='SEXUAL-RISK-7').answer.valueCoding.extension('http://hl7.org/fhir/StructureDefinition/ordinalValue').valueDecimal.toInteger()) + iif(%resource.item.where(linkId='SEXUAL-RISK-8').answer.empty(), 0, %resource.item.where(linkId='SEXUAL-RISK-8').answer.valueCoding.extension('http://hl7.org/fhir/StructureDefinition/ordinalValue').valueDecimal.toInteger()) + iif(%resource.item.where(linkId='SEXUAL-RISK-9').answer.empty(), 0, %resource.item.where(linkId='SEXUAL-RISK-9').answer.valueCoding.extension('http://hl7.org/fhir/StructureDefinition/ordinalValue').valueDecimal.toInteger()))"
-          }
-        }
-      ]
-    },
-    {
-      "linkId": "SEXUAL-RISK-score-interpretation",
-      "text": "CNICS SEXUAL-RISK score interpretation",
-      "type": "string",
-      "readOnly": true,
-      "extension": [
-        {
-          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
-          "valueExpression": {
-            "language": "text/fhirpath",
-            "expression": "iif(%patient.gender = 'male' and %resource.item.where(linkId='SEXUAL-RISK-score').answer.valueDecimal.toInteger() >= 6, 'At-risk', iif(%patient.gender != 'male' and %resource.item.where(linkId='SEXUAL-RISK-score').answer.valueDecimal.toInteger() >= 5, 'At-risk', iif((%resource.item.where(linkId='SEXUAL-RISK-score').answer.empty() != true), 'Not at-risk', null)))"
-          }
-        }
-      ]
-    },
-    {
-      "linkId": "SEXUAL-RISK-qnr-to-report",
-      "text": "Which CNICS SEXUAL-RISK score to display. Returns 'SEXUAL-RISK', 'SEXUAL-RISK-C', or null.",
-      "type": "string",
-      "readOnly": true,
-      "extension": [
-        {
-          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
-          "valueExpression": {
-            "language": "text/fhirpath",
-            "expression": "iif(%resource.item.where(linkId='SEXUAL-RISK-last-7-any-answers').answer.valueBoolean.toBoolean() = true, 'SEXUAL-RISK', iif(%resource.item.where(linkId='SEXUAL-RISK-0').answer.empty() = false, 'SEXUAL-RISK-C', null))"
+            "expression": "true"
           }
         }
       ]


### PR DESCRIPTION
This reports according to the spec ([here](https://docs.google.com/spreadsheets/d/1pVNAtala7-COYfKuB2RGQFyXzAM8asre/edit?gid=465916445#gid=465916445&range=A43)), namely, simpler than the dhair reporting (screenshot in my Jan 5 comment below). 

- "# of sex partners X 3 mos" `SEXUAL-RISK-SCORE-NUM-PARTNERS`
- "Unprotected sex" `SEXUAL-RISK-SCORE-UNPROTECTED`
  - This change also implements these three sub-components, which dhair distinguishes, and which we may eventually want to include int the SoF app: `SEXUAL-RISK-SCORE-UNPROTECTED-ANAL`, `SEXUAL-RISK-SCORE-UNPROTECTED-ORAL`, `SEXUAL-RISK-SCORE-UNPROTECTED-VAGINAL`.
- "Concern for STI" `SEXUAL-RISK-SCORE-STI-EXPOSURE`

To clarify, the section in the spec also has "Exchange sex (recent)", but that will come from a different Questionnaire / PR.

Corresponding dhair implementation: https://gitlab.cirg.washington.edu/svn/dhair/-/merge_requests/1009 