### PR TITLE
Implements sexual risk scores from dhair2 "Number of partners" cell (much more than just a number...)

### DIFF
--- a/CIRG-CNICS-SEXUAL-RISK.json
+++ b/CIRG-CNICS-SEXUAL-RISK.json
@@ -1080,6 +1080,36 @@
       ]
     },
     {
+      "linkId": "SEXUAL-RISK-SCORE-ONE-PARTNER",
+      "text": "Whether the answer to \"Approximately how many sex partners have you had in the past 3 months?\" is 1. For internal use only. THIS HAS BEEN TESTED FOR NON-RESPONSE AND VARIOUS RESPONSES TO SEXUAL-RISK-0.",
+      "type": "boolean",
+      "readOnly": true,
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "(%resource.item.where(linkId='SEXUAL-RISK-0').answer.empty() != true) and %resource.item.where(linkId='SEXUAL-RISK-0').answer.valueCoding.code = 'SEXUAL-RISK-0-1'"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-SCORE-MULTIPLE-PARTNERS",
+      "text": "Whether the answer to \"Approximately how many sex partners have you had in the past 3 months?\" is more than 1. For internal use only. THIS HAS BEEN TESTED FOR NON-RESPONSE AND VARIOUS RESPONSES TO SEXUAL-RISK-0.",
+      "type": "boolean",
+      "readOnly": true,
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "(%resource.item.where(linkId='SEXUAL-RISK-0').answer.empty() != true) and ((%resource.item.where(linkId='SEXUAL-RISK-0').answer.valueCoding.code = 'SEXUAL-RISK-0-2') or (%resource.item.where(linkId='SEXUAL-RISK-0').answer.valueCoding.code = 'SEXUAL-RISK-0-3') or (%resource.item.where(linkId='SEXUAL-RISK-0').answer.valueCoding.code = 'SEXUAL-RISK-0-4'))"
+          }
+        }
+      ]
+    },
+    {
       "linkId": "SEXUAL-RISK-SCORE-PARTNERS-GENDERS",
       "text": "Genders of partner(s).",
       "type": "string",
@@ -1095,8 +1125,8 @@
       ]
     },
     {
-      "linkId": "SEXUAL-RISK-SCORE-PARTNERS-HIV-STATUS",
-      "text": "HIV status of partner(s), and whether they were prescribed PrEP. THIS IS JUST A STUB, NOT YET USED.",
+      "linkId": "SEXUAL-RISK-SCORE-PARTNERS-HIV-NEG-PREP",
+      "text": "Whether any partners were HIV negative, and if so whether they were prescribed PrEP.",
       "type": "string",
       "readOnly": true,
       "extension": [
@@ -1104,7 +1134,37 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
           "valueExpression": {
             "language": "text/fhirpath",
-            "expression": "'TBD'"
+            "expression": "iif(%resource.item.where(linkId='SEXUAL-RISK-SCORE-ONE-PARTNER').answer.valueBoolean.toBoolean() = true, iif(%resource.item.where(linkId='SEXUAL-RISK-4').answer.valueCoding.code = 'SEXUAL-RISK-4-0','HIV negative partner: prescribed PrEP', iif(%resource.item.where(linkId='SEXUAL-RISK-4').answer.valueCoding.code = 'SEXUAL-RISK-4-1','HIV negative partner: not prescribed PrEP', iif(%resource.item.where(linkId='SEXUAL-RISK-4').answer.valueCoding.code = 'SEXUAL-RISK-4-2','HIV negative partner: PrEP use unknown',''))), iif(%resource.item.where(linkId='SEXUAL-RISK-SCORE-MULTIPLE-PARTNERS').answer.valueBoolean.toBoolean() = true, iif(%resource.item.where(linkId='SEXUAL-RISK-26').answer.valueCoding.code = 'SEXUAL-RISK-26-0','HIV negative partner(s): all prescribed PrEP', iif(%resource.item.where(linkId='SEXUAL-RISK-26').answer.valueCoding.code = 'SEXUAL-RISK-26-1','HIV negative partner(s): some prescribed PrEP', iif(%resource.item.where(linkId='SEXUAL-RISK-26').answer.valueCoding.code = 'SEXUAL-RISK-26-2','HIV negative partner(s): none prescribed PrEP', iif(%resource.item.where(linkId='SEXUAL-RISK-26').answer.valueCoding.code = 'SEXUAL-RISK-26-3','HIV negative partner(s): PrEP use unknown','')))),''))"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-SCORE-PARTNERS-HIV-POS-ARV",
+      "text": "Whether any partners were HIV positive, and if so whether they are on ARVs.",
+      "type": "string",
+      "readOnly": true,
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "iif(%resource.item.where(linkId='SEXUAL-RISK-SCORE-ONE-PARTNER').answer.valueBoolean.toBoolean() = true, iif(%resource.item.where(linkId='SEXUAL-RISK-3').answer.valueCoding.code = 'SEXUAL-RISK-3-0','HIV positive partner: prescribed ARVs', iif(%resource.item.where(linkId='SEXUAL-RISK-3').answer.valueCoding.code = 'SEXUAL-RISK-3-1','HIV positive partner: not prescribed ARVs', iif(%resource.item.where(linkId='SEXUAL-RISK-3').answer.valueCoding.code = 'SEXUAL-RISK-3-2','HIV positive partner: ARV use unknown',''))), iif(%resource.item.where(linkId='SEXUAL-RISK-SCORE-MULTIPLE-PARTNERS').answer.valueBoolean.toBoolean() = true, iif(%resource.item.where(linkId='SEXUAL-RISK-25').answer.valueCoding.code = 'SEXUAL-RISK-25-0','HIV positive partner(s): all prescribed ARVs', iif(%resource.item.where(linkId='SEXUAL-RISK-25').answer.valueCoding.code = 'SEXUAL-RISK-25-1','HIV positive partner(s): some prescribed ARVs', iif(%resource.item.where(linkId='SEXUAL-RISK-25').answer.valueCoding.code = 'SEXUAL-RISK-25-2','HIV positive partner(s): none prescribed ARVs', iif(%resource.item.where(linkId='SEXUAL-RISK-25').answer.valueCoding.code = 'SEXUAL-RISK-25-3','HIV positive partner(s): ARV use unknown','')))),''))"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "SEXUAL-RISK-SCORE-PARTNERS-HIV-UNKNOWN",
+      "text": "Whether any partners have an unknown HIV status.",
+      "type": "string",
+      "readOnly": true,
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "iif(%resource.item.where(linkId='SEXUAL-RISK-SCORE-ONE-PARTNER').answer.valueBoolean.toBoolean() = true, iif(%resource.item.where(linkId='SEXUAL-RISK-2').answer.valueCoding.code = 'SEXUAL-RISK-2-2','Partner with unknown HIV status', ''), iif(%resource.item.where(linkId='SEXUAL-RISK-SCORE-MULTIPLE-PARTNERS').answer.valueBoolean.toBoolean() = true, iif(%resource.item.where(linkId='SEXUAL-RISK-24').answer.valueCoding.where(code = 'SEXUAL-RISK-24-2' or code = 'SEXUAL-RISK-24-3').exists(),'Partner(s) with unknown HIV status', ''), ''))"
           }
         }
       ]

--- a/CIRG-CNICS-SEXUAL-RISK.json
+++ b/CIRG-CNICS-SEXUAL-RISK.json
@@ -1081,7 +1081,7 @@
     },
     {
       "linkId": "SEXUAL-RISK-SCORE-PARTNERS-GENDERS",
-      "text": "Genders of partner(s). THIS IS JUST A STUB, NOT YET USED.",
+      "text": "Genders of partner(s).",
       "type": "string",
       "readOnly": true,
       "extension": [
@@ -1089,7 +1089,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
           "valueExpression": {
             "language": "text/fhirpath",
-            "expression": "'TBD'"
+            "expression": "iif(%resource.item.where(linkId='SEXUAL-RISK-1').answer.empty(), '', %resource.item.where(linkId='SEXUAL-RISK-1').answer.valueCoding.display + '; ') + iif(%resource.item.where(linkId='SEXUAL-RISK-18').answer.empty() or %resource.item.where(linkId='SEXUAL-RISK-18').answer.valueCoding.code = 'SEXUAL-RISK-18-3', '', %resource.item.where(linkId='SEXUAL-RISK-18').answer.valueCoding.display + ' male; ') + iif(%resource.item.where(linkId='SEXUAL-RISK-19').answer.empty() or %resource.item.where(linkId='SEXUAL-RISK-19').answer.valueCoding.code = 'SEXUAL-RISK-19-3', '',  %resource.item.where(linkId='SEXUAL-RISK-19').answer.valueCoding.display + ' female; ') + iif(%resource.item.where(linkId='SEXUAL-RISK-20').answer.empty() or %resource.item.where(linkId='SEXUAL-RISK-20').answer.valueCoding.code = 'SEXUAL-RISK-20-3', '',  %resource.item.where(linkId='SEXUAL-RISK-20').answer.valueCoding.display + ' male-to-female; ') + iif(%resource.item.where(linkId='SEXUAL-RISK-21').answer.empty() or %resource.item.where(linkId='SEXUAL-RISK-21').answer.valueCoding.code = 'SEXUAL-RISK-21-3', '',  %resource.item.where(linkId='SEXUAL-RISK-21').answer.valueCoding.display + ' female-to-male; ') + iif(%resource.item.where(linkId='SEXUAL-RISK-22').answer.empty() or %resource.item.where(linkId='SEXUAL-RISK-22').answer.valueCoding.code = 'SEXUAL-RISK-22-3', '',  %resource.item.where(linkId='SEXUAL-RISK-22').answer.valueCoding.display + ' no specific gender; ') + iif(%resource.item.where(linkId='SEXUAL-RISK-23').answer.empty() or %resource.item.where(linkId='SEXUAL-RISK-23').answer.valueCoding.code = 'SEXUAL-RISK-23-3', '',  %resource.item.where(linkId='SEXUAL-RISK-23').answer.valueCoding.display + ' unknown')"
           }
         }
       ]


### PR DESCRIPTION
The SoF app splits the dhair2 "Number of partners" reportables into two rows:
1. "# of Sex Partners". This is SEXUAL-RISK-SCORE-NUM-PARTNERS, a string e.g. "None", "2", "11-20". This was implemented in an earlier PR.
2. "Partner(s) Context" - this PR. There are 4 scores for this; each goes on it's own line; details below.

First line: SEXUAL-RISK-SCORE-PARTNERS-GENDERS - implemented, tested, new Questionnaire on dev & test Hapi, QR's on dev.
The remaining 3 scores might be empty strings. **_If they are empty, don't include the line_** (as opposed to showing something liker 'N/A' or '-').
Second line: SEXUAL-RISK-SCORE-PARTNERS-HIV-NEG-PREP. e.g. "HIV negative partner: PrEP use unknown", "HIV negative partner(s): Some prescribed PrEP".
Third line: SEXUAL-RISK-SCORE-PARTNERS-HIV-POS-ARV. e.g. "HIV positive partner: ARV use unknown", "HIV positive partner(s): All prescribed ARVs".
Fourth line: SEXUAL-RISK-SCORE-PARTNERS-HIV-UNKNOWN. e.g. "Partner w/ unknown HIV status", "Partner(s) w/ unknown HIV status"


Some screenshots of what this info looks like in the dhair2 report:
<img width="1289" height="396" alt="image" src="https://github.com/user-attachments/assets/0f7f1190-0a2e-4980-99a1-c781b0e68ed2" />

<img width="306" height="159" alt="image" src="https://github.com/user-attachments/assets/ca62a9f7-6469-448f-893d-793855e8103b" />
<img width="304" height="157" alt="image" src="https://github.com/user-attachments/assets/e5aca189-88c2-4ea5-969e-b83125ab0914" />
<img width="300" height="156" alt="image" src="https://github.com/user-attachments/assets/276504f3-88ae-44f4-ab47-378dc3f1c4c2" />

