### PR TITLE
Adds the CIRG-CNICS-EXCHANGE-SEX Questionnaire.

### DIFF
--- a/CIRG-CNICS-EXCHANGE-SEX.json
+++ b/CIRG-CNICS-EXCHANGE-SEX.json
@@ -44,6 +44,80 @@
       ]
     },
     {
+      "linkId": "EXCHANGE-SEX-2",
+      "text": "Which of these things did you have sex for? Please check all that apply.",
+      "type": "choice",
+      "repeats": true,
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "EXCHANGE-SEX-2-0",
+            "display": "Place to stay/sleep"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "EXCHANGE-SEX-2-1",
+            "display": "Food"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "EXCHANGE-SEX-2-2",
+            "display": "Clothing"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "EXCHANGE-SEX-2-3",
+            "display": "Drugs"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "EXCHANGE-SEX-2-4",
+            "display": "Money"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "EXCHANGE-SEX-2-5",
+            "display": "Security/protection"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "EXCHANGE-SEX-2-6",
+            "display": "Transportation"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "EXCHANGE-SEX-2-7",
+            "display": "Medication"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "EXCHANGE-SEX-2-8",
+            "display": "Child care"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "EXCHANGE-SEX-2-9",
+            "display": "Something else"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "EXCHANGE-SEX-2-10",
+            "display": "Prefer not to say"
+          }
+        }
+      ]
+    },
+    {
       "linkId": "EXCHANGE-SEX-3",
       "text": "Which of these things did you have sex for? Please check all that apply.",
       "type": "choice",
@@ -114,88 +188,29 @@
             "code": "EXCHANGE-SEX-3-10",
             "display": "Prefer not to say"
           }
-        }
-      ]
-    },
-    {
-      "linkId": "EXCHANGE-SEX-4",
-      "text": "Which of these things did you have sex for? Please check all that apply.",
-      "type": "choice",
-      "repeats": true,
-      "answerOption": [
-        {
-          "valueCoding": {
-            "code": "EXCHANGE-SEX-4-0",
-            "display": "Place to stay/sleep"
-          }
         },
         {
           "valueCoding": {
-            "code": "EXCHANGE-SEX-4-1",
-            "display": "Food"
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "EXCHANGE-SEX-4-2",
-            "display": "Clothing"
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "EXCHANGE-SEX-4-3",
-            "display": "Drugs"
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "EXCHANGE-SEX-4-4",
-            "display": "Money"
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "EXCHANGE-SEX-4-5",
-            "display": "Security/protection"
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "EXCHANGE-SEX-4-6",
-            "display": "Transportation"
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "EXCHANGE-SEX-4-7",
-            "display": "Medication"
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "EXCHANGE-SEX-4-8",
-            "display": "Child care"
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "EXCHANGE-SEX-4-9",
-            "display": "Something else"
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "EXCHANGE-SEX-4-10",
-            "display": "Prefer not to say"
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "EXCHANGE-SEX-4-11",
+            "code": "EXCHANGE-SEX-3-11",
             "display": "None of the above"
           }
         }
       ]
+    },
+    {
+      "linkId": "EXCHANGE-SEX-SCORE-PAST-3-MONTHS",
+      "text": "Whether the patient indicated an exchange for sex in the past 3 months.",
+      "type": "string",
+      "readOnly": true,
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "iif(%resource.item.where(linkId='EXCHANGE-SEX-1').answer.empty() = false, %resource.item.where(linkId='EXCHANGE-SEX-1').answer.valueCoding.display, iif(%resource.item.where(linkId='EXCHANGE-SEX-3').answer.empty(),'', iif(%resource.item.where(linkId='EXCHANGE-SEX-3').answer.valueCoding.where(code = 'EXCHANGE-SEX-3-10').exists(),'', iif(%resource.item.where(linkId='EXCHANGE-SEX-3').answer.valueCoding.where(code = 'EXCHANGE-SEX-3-11').exists(),'No','Yes'))))"
+          }
+        }
+      ] 
     }
   ]
 }

--- a/CIRG-CNICS-EXCHANGE-SEX.json
+++ b/CIRG-CNICS-EXCHANGE-SEX.json
@@ -1,0 +1,201 @@
+{
+  "resourceType": "Questionnaire",
+  "id": "CIRG-CNICS-EXCHANGE-SEX",
+  "title": "CNICS Exchange Sex Questionnaire",
+  "status": "active",
+  "description": "CNICS Exchange Sex Questionnaire.",
+  "item": [
+    {
+      "linkId": "EXCHANGE-SEX-0",
+      "text": "Have you ever had sex for shelter, food, clothing, drugs, money, or any other goods?",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "EXCHANGE-SEX-0-0",
+            "display": "Yes"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "EXCHANGE-SEX-0-1",
+            "display": "No"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "EXCHANGE-SEX-1",
+      "text": "Did you have sex for any of these things in the past 3 months?",
+      "type": "choice",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "EXCHANGE-SEX-1-0",
+            "display": "Yes"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "EXCHANGE-SEX-1-1",
+            "display": "No"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "EXCHANGE-SEX-3",
+      "text": "Which of these things did you have sex for? Please check all that apply.",
+      "type": "choice",
+      "repeats": true,
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "EXCHANGE-SEX-3-0",
+            "display": "Place to stay/sleep"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "EXCHANGE-SEX-3-1",
+            "display": "Food"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "EXCHANGE-SEX-3-2",
+            "display": "Clothing"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "EXCHANGE-SEX-3-3",
+            "display": "Drugs"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "EXCHANGE-SEX-3-4",
+            "display": "Money"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "EXCHANGE-SEX-3-5",
+            "display": "Security/protection"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "EXCHANGE-SEX-3-6",
+            "display": "Transportation"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "EXCHANGE-SEX-3-7",
+            "display": "Medication"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "EXCHANGE-SEX-3-8",
+            "display": "Child care"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "EXCHANGE-SEX-3-9",
+            "display": "Something else"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "EXCHANGE-SEX-3-10",
+            "display": "Prefer not to say"
+          }
+        }
+      ]
+    },
+    {
+      "linkId": "EXCHANGE-SEX-4",
+      "text": "Which of these things did you have sex for? Please check all that apply.",
+      "type": "choice",
+      "repeats": true,
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "EXCHANGE-SEX-4-0",
+            "display": "Place to stay/sleep"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "EXCHANGE-SEX-4-1",
+            "display": "Food"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "EXCHANGE-SEX-4-2",
+            "display": "Clothing"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "EXCHANGE-SEX-4-3",
+            "display": "Drugs"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "EXCHANGE-SEX-4-4",
+            "display": "Money"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "EXCHANGE-SEX-4-5",
+            "display": "Security/protection"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "EXCHANGE-SEX-4-6",
+            "display": "Transportation"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "EXCHANGE-SEX-4-7",
+            "display": "Medication"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "EXCHANGE-SEX-4-8",
+            "display": "Child care"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "EXCHANGE-SEX-4-9",
+            "display": "Something else"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "EXCHANGE-SEX-4-10",
+            "display": "Prefer not to say"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "EXCHANGE-SEX-4-11",
+            "display": "None of the above"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
@achen2401  the only thing here to include in the SoF report is `EXCHANGE-SEX-SCORE-PAST-3-MONTHS`. 

You currently have this placeholder in the Sexual Risk:
<img width="587" height="511" alt="image" src="https://github.com/user-attachments/assets/c02039ac-e1c2-40ff-af41-d468af64ff72" />

That's where it belongs. Please change "_Exchange Sex_" to follow the same pattern as the other subsections:

**Exchange Sex**
Past 3 months

... and show the response to EXCHANGE-SEX-1 in the "Result" column. It is a string and will be either "Yes", "No", or "".

-----

This is now on the dev and test servers.

dhair implementation: https://gitlab.cirg.washington.edu/svn/dhair/-/merge_requests/1016 

I'll add sample QR's as a comment shortly...